### PR TITLE
Refactor/start logic

### DIFF
--- a/js/core/GameInputController.js
+++ b/js/core/GameInputController.js
@@ -165,39 +165,4 @@ export class GameInputController {
             }
         });
     }
-
-    /**
-     * Highlight the next grid square in the START sequence
-     */
-    highlightNextStartGuide() {
-        if (!this.game.startSequence.isActive || this.game.startSequence.currentIndex >= CONFIG.PREVIEW_START.LETTERS.length) {
-            return; // START sequence not active or complete
-        }
-        
-        const expected = this.game.startSequence.getCurrentExpectedPosition();
-        const column = expected.column;
-
-        // Highlight only the configured focus square for this letter
-        const focusIndex = calculateIndex(expected.row, column, CONFIG.GRID.COLUMNS);
-        const focusSquare = this.game.dom.getGridSquare(focusIndex);
-        if (focusSquare) {
-            focusSquare.classList.add('start-guide');
-        }
-
-        console.log(`Highlighting single square at row ${expected.row}, column ${column}`);
-    }
-
-    /**
-     * Clear the current START guide highlight
-     */
-    clearStartGuide() {
-        // Remove start-guide and focus classes from all highlighted squares
-        const highlighted = this.game.dom.grid.querySelectorAll('.start-guide, .start-guide-focus');
-        highlighted.forEach(sq => {
-            sq.classList.remove('start-guide');
-            sq.classList.remove('start-guide-focus');
-        });
-    }
-
-
 }


### PR DESCRIPTION
This pull request refactors the handling of UI updates related to the "START" sequence in the game. The main change is moving the responsibility for highlighting and clearing the start guide from the `GameInputController` to the `startUI` component, improving code organization and separation of concerns.

**Refactoring and Responsibility Shift:**

* Replaced direct calls to `highlightNextStartGuide`, `clearStartGuide`, and `updateStartPreviewAfterDrop` in `GameInputController` with corresponding methods on `this.game.startUI`, delegating UI responsibilities to the `startUI` component. [[1]](diffhunk://#diff-68abf5c3f6925dc393af27201805a2b5c011abec57353288d4988955e421f073L83-R83) [[2]](diffhunk://#diff-68abf5c3f6925dc393af27201805a2b5c011abec57353288d4988955e421f073L95-R95) [[3]](diffhunk://#diff-68abf5c3f6925dc393af27201805a2b5c011abec57353288d4988955e421f073L105-R105)
* Removed the `highlightNextStartGuide` and `clearStartGuide` methods from `GameInputController`, as these are now handled by `startUI`.