### PR TITLE
Feat: UI improvements: start menu redesign, letter preview reactivity, and visual polish

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -60,8 +60,8 @@ function App() {
     }
   };
 
-  // Get next 5 letters from queue
-  const nextLetters = state.nextQueue.slice(0, 5).map(item => item.char);
+  // Pass enough letters to cover max in-flight drops (7 cols) + 5 visible in preview
+  const nextLetters = state.nextQueue.slice(0, 12).map(item => item.char);
 
   return (
     <>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,33 +8,22 @@ import { useTutorial } from './hooks/useTutorial.js';
 
 function App() {
   const { state, dispatch } = useGame();
-  const { dictionary } = useGameLogic();
+  const { dictionary, loading: dictLoading } = useGameLogic();
   const [isMuted, setIsMuted] = useState(false);
   const [showModeSelector, setShowModeSelector] = useState(false);
   const tutorial = useTutorial(state, dispatch, () => {
     setShowModeSelector(true);
   });
 
-  // Show loading state while dictionary loads
-  if (!dictionary) {
-    return (
-      <div className="main-container" style={{
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        height: '100vh',
-        fontSize: '1.5rem'
-      }}>
-        Loading dictionary...
-      </div>
-    );
-  }
-
   const handleStart = () => {
     setShowModeSelector(true);
   };
 
   const handleModeSelect = (mode) => {
+    // Don't start game if dictionary isn't loaded yet
+    if (!dictionary) {
+      return;
+    }
     setShowModeSelector(false);
     dispatch({ type: 'START_GAME', payload: { mode } });
     if (mode === 'tutorial') {
@@ -65,30 +54,58 @@ function App() {
 
   return (
     <>
-      <GameLayout
-        score={state.score}
-        lettersRemaining={state.lettersRemaining}
-        nextLetters={nextLetters}
-        grid={state.grid}
-        madeWords={state.madeWords}
-        dictionary={dictionary}
-        onStart={handleStart}
-        onMute={handleMute}
-        onColumnClick={handleColumnClick}
-        isMuted={isMuted}
-        showPreview={state.status === 'PLAYING' || state.status === 'PROCESSING'}
-        canDrop={tutorial.canDrop}
-        tutorialStep={tutorial.tutorialStep}
-        tutorialMessage={tutorial.tutorialMessage}
-        showNextButton={tutorial.showNextButton}
-        showBackButton={tutorial.showBackButton}
-        dimElements={tutorial.dimElements}
-        highlightPreview={tutorial.highlightPreview}
-        highlightColumn={tutorial.highlightColumn}
-        onTutorialNext={tutorial.handleTutorialNext}
-        onTutorialBack={tutorial.handleBack}
-      />
+      {dictionary ? (
+        <GameLayout
+          score={state.score}
+          lettersRemaining={state.lettersRemaining}
+          nextLetters={nextLetters}
+          grid={state.grid}
+          madeWords={state.madeWords}
+          dictionary={dictionary}
+          onStart={handleStart}
+          onMute={handleMute}
+          onColumnClick={handleColumnClick}
+          isMuted={isMuted}
+          showPreview={state.status === 'PLAYING' || state.status === 'PROCESSING'}
+          canDrop={tutorial.canDrop}
+          tutorialStep={tutorial.tutorialStep}
+          tutorialMessage={tutorial.tutorialMessage}
+          showNextButton={tutorial.showNextButton}
+          showBackButton={tutorial.showBackButton}
+          dimElements={tutorial.dimElements}
+          highlightPreview={tutorial.highlightPreview}
+          highlightColumn={tutorial.highlightColumn}
+          onTutorialNext={tutorial.handleTutorialNext}
+          onTutorialBack={tutorial.handleBack}
+        />
+      ) : (
+        <div className="main-container" style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '100vh',
+          fontSize: '1.5rem'
+        }}>
+          Loading dictionary...
+        </div>
+      )}
       <ModeSelector visible={showModeSelector} onSelectMode={handleModeSelect} />
+      {dictLoading && showModeSelector && (
+        <div style={{
+          position: 'fixed',
+          bottom: '20px',
+          left: '50%',
+          transform: 'translateX(-50%)',
+          backgroundColor: 'rgba(0, 0, 0, 0.7)',
+          color: 'white',
+          padding: '10px 20px',
+          borderRadius: '4px',
+          fontSize: '0.9rem',
+          zIndex: 1001
+        }}>
+          Loading dictionary...
+        </div>
+      )}
       <GameOverOverlay
         visible={state.status === 'GAME_OVER'}
         gameMode={state.gameMode}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,7 @@ function App() {
   const { state, dispatch } = useGame();
   const { dictionary, loading: dictLoading } = useGameLogic();
   const [isMuted, setIsMuted] = useState(false);
-  const [showModeSelector, setShowModeSelector] = useState(false);
+  const [showModeSelector, setShowModeSelector] = useState(true);
   const tutorial = useTutorial(state, dispatch, () => {
     setShowModeSelector(true);
   });

--- a/src/components/Controls/Actions.jsx
+++ b/src/components/Controls/Actions.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 function Actions({ onStart, onMute, isMuted = false }) {
   return (
     <div className="controls">
-      <button className="start-btn" onClick={onStart}>
-        🎮
+      <button className="start-btn" onClick={onStart} title="Open menu">
+        ☰
       </button>
       <button className="mute-btn" onClick={onMute}>
         {isMuted ? '🔇' : '🔊'}

--- a/src/components/Controls/ModeSelector.jsx
+++ b/src/components/Controls/ModeSelector.jsx
@@ -22,13 +22,13 @@ function ModeSelector({ visible, onSelectMode }) {
               className="mode-selection-btn classic-btn"
               onClick={() => handleModeSelect('classic')}
             >
-              🕹️ Classic
+              Classic <span className="btn-emoji">🕹️</span>
             </button>
             <button
               className="mode-selection-btn clear-btn"
               onClick={() => handleModeSelect('clear')}
             >
-              🧹 Clear
+              Clear <span className="btn-emoji">🧹</span>
             </button>
           </div>
         </div>

--- a/src/components/Controls/ModeSelector.jsx
+++ b/src/components/Controls/ModeSelector.jsx
@@ -18,24 +18,20 @@ function ModeSelector({ visible, onSelectMode }) {
         <div className="mode-selection-section">
           <h3 className="mode-selection-section-title">Play Game</h3>
           <div className="mode-selection-buttons">
-            <div className="mode-button-group">
-              <button
-                className="mode-selection-btn classic-btn"
-                onClick={() => handleModeSelect('classic')}
-              >
-                Classic <span className="btn-emoji">🕹️</span>
-              </button>
-              <p className="mode-description">Score big with 100 letters.</p>
-            </div>
-            <div className="mode-button-group">
-              <button
-                className="mode-selection-btn clear-btn"
-                onClick={() => handleModeSelect('clear')}
-              >
-                Clear <span className="btn-emoji">🧹</span>
-              </button>
-              <p className="mode-description">Wipe the board of all tiles.</p>
-            </div>
+            <button
+              className="mode-selection-btn classic-btn"
+              onClick={() => handleModeSelect('classic')}
+            >
+              <span className="btn-title">Classic <span className="btn-emoji">🕹️</span></span>
+              <span className="btn-description">Score big with 100 letters.</span>
+            </button>
+            <button
+              className="mode-selection-btn clear-btn"
+              onClick={() => handleModeSelect('clear')}
+            >
+              <span className="btn-title">Clear <span className="btn-emoji">🧹</span></span>
+              <span className="btn-description">Wipe the board of all tiles.</span>
+            </button>
           </div>
         </div>
 

--- a/src/components/Controls/ModeSelector.jsx
+++ b/src/components/Controls/ModeSelector.jsx
@@ -22,13 +22,13 @@ function ModeSelector({ visible, onSelectMode }) {
               className="mode-selection-btn classic-btn"
               onClick={() => handleModeSelect('classic')}
             >
-              Classic
+              🕹️ Classic
             </button>
             <button
               className="mode-selection-btn clear-btn"
               onClick={() => handleModeSelect('clear')}
             >
-              Clear
+              🧹 Clear
             </button>
           </div>
         </div>

--- a/src/components/Controls/ModeSelector.jsx
+++ b/src/components/Controls/ModeSelector.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
 /**
- * Mode selector modal - allows user to choose between Classic and Clear modes
- * @param {boolean} visible - Whether the modal should be visible
- * @param {function} onSelectMode - Callback when a mode is selected (receives 'classic' or 'clear')
+ * Start menu - allows user to choose between game modes and tutorial
+ * @param {boolean} visible - Whether the menu should be visible
+ * @param {function} onSelectMode - Callback when a mode is selected (receives 'classic', 'clear', or 'tutorial')
  */
 function ModeSelector({ visible, onSelectMode }) {
   const handleModeSelect = (mode) => {
@@ -13,26 +13,36 @@ function ModeSelector({ visible, onSelectMode }) {
   return (
     <div className={`mode-selection-menu ${visible ? 'visible' : ''}`}>
       <div className="mode-selection-content">
-        <h2 className="mode-selection-title">Select Game Mode</h2>
-        <div className="mode-selection-buttons">
-          <button
-            className="mode-selection-btn classic-btn"
-            onClick={() => handleModeSelect('classic')}
-          >
-            Classic
-          </button>
-          <button
-            className="mode-selection-btn clear-btn"
-            onClick={() => handleModeSelect('clear')}
-          >
-            Clear
-          </button>
-          <button
-            className="mode-selection-btn tutorial-btn"
-            onClick={() => handleModeSelect('tutorial')}
-          >
-            Tutorial
-          </button>
+        <h2 className="mode-selection-title">Start Menu</h2>
+
+        <div className="mode-selection-section">
+          <h3 className="mode-selection-section-title">Play Game</h3>
+          <div className="mode-selection-buttons">
+            <button
+              className="mode-selection-btn classic-btn"
+              onClick={() => handleModeSelect('classic')}
+            >
+              Classic
+            </button>
+            <button
+              className="mode-selection-btn clear-btn"
+              onClick={() => handleModeSelect('clear')}
+            >
+              Clear
+            </button>
+          </div>
+        </div>
+
+        <div className="mode-selection-section">
+          <h3 className="mode-selection-section-title">Learn</h3>
+          <div className="mode-selection-buttons">
+            <button
+              className="mode-selection-btn tutorial-btn"
+              onClick={() => handleModeSelect('tutorial')}
+            >
+              Tutorial
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/Controls/ModeSelector.jsx
+++ b/src/components/Controls/ModeSelector.jsx
@@ -18,18 +18,24 @@ function ModeSelector({ visible, onSelectMode }) {
         <div className="mode-selection-section">
           <h3 className="mode-selection-section-title">Play Game</h3>
           <div className="mode-selection-buttons">
-            <button
-              className="mode-selection-btn classic-btn"
-              onClick={() => handleModeSelect('classic')}
-            >
-              Classic <span className="btn-emoji">🕹️</span>
-            </button>
-            <button
-              className="mode-selection-btn clear-btn"
-              onClick={() => handleModeSelect('clear')}
-            >
-              Clear <span className="btn-emoji">🧹</span>
-            </button>
+            <div className="mode-button-group">
+              <button
+                className="mode-selection-btn classic-btn"
+                onClick={() => handleModeSelect('classic')}
+              >
+                Classic <span className="btn-emoji">🕹️</span>
+              </button>
+              <p className="mode-description">Score big with 100 letters.</p>
+            </div>
+            <div className="mode-button-group">
+              <button
+                className="mode-selection-btn clear-btn"
+                onClick={() => handleModeSelect('clear')}
+              >
+                Clear <span className="btn-emoji">🧹</span>
+              </button>
+              <p className="mode-description">Wipe the board of all tiles.</p>
+            </div>
           </div>
         </div>
 

--- a/src/components/Controls/NextPreview.jsx
+++ b/src/components/Controls/NextPreview.jsx
@@ -1,6 +1,6 @@
 const ORDINALS = ['1st', '2nd', '3rd', '4th', '5th'];
 
-function NextPreview({ nextLetters = [], visible = false, nextUpRef, showOrdinals = false }) {
+function NextPreview({ nextLetters = [], visible = false, nextUpRef, showOrdinals = false, shiftKey = 0 }) {
   const displayLetters = nextLetters.slice(0, 5);
 
   return (
@@ -12,8 +12,10 @@ function NextPreview({ nextLetters = [], visible = false, nextUpRef, showOrdinal
         let className = 'block-base preview-letter-block';
         if (isNextUp) className += ' next-up';
         if (isEmpty) className += ' empty';
+        // Remount the next-up slot on each shift so the CSS pop animation replays
+        const slotKey = index === 0 ? shiftKey : index;
         return (
-          <div key={index} className="tutorial-preview-slot">
+          <div key={slotKey} className="tutorial-preview-slot">
             {showOrdinals && (
               <div className="tutorial-ordinal">{ORDINALS[index]}</div>
             )}

--- a/src/components/Controls/NextPreview.jsx
+++ b/src/components/Controls/NextPreview.jsx
@@ -12,8 +12,10 @@ function NextPreview({ nextLetters = [], visible = false, nextUpRef, showOrdinal
         let className = 'block-base preview-letter-block';
         if (isNextUp) className += ' next-up';
         if (isEmpty) className += ' empty';
-        // Remount the next-up slot on each shift so the CSS pop animation replays
-        const slotKey = index === 0 ? shiftKey : index;
+        // Remount the next-up slot on each shift so the CSS pop animation replays.
+        // Use a string prefix for index 0 to avoid key collisions with sibling slots
+        // (e.g. shiftKey=1 would otherwise clash with slot index=1).
+        const slotKey = index === 0 ? `next-up-${shiftKey}` : index;
         return (
           <div key={slotKey} className="tutorial-preview-slot">
             {showOrdinals && (

--- a/src/components/Grid/Cell.jsx
+++ b/src/components/Grid/Cell.jsx
@@ -26,16 +26,6 @@ const computePendingStyles = (directions) => {
     shadows.push('inset 0 -3px 0 0 var(--color-pending-vertical)');
   }
 
-  // Check for diagonal-down-right (all 4 borders)
-  if (directions.includes('diagonal-down-right')) {
-    shadows.push('inset 0 0 0 3px var(--color-pending-diagonal-down-right)');
-  }
-
-  // Check for diagonal-up-right (all 4 borders)
-  if (directions.includes('diagonal-up-right')) {
-    shadows.push('inset 0 0 0 3px var(--color-pending-diagonal-up-right)');
-  }
-
   return {
     boxShadow: shadows.length > 0 ? shadows.join(', ') : undefined
   };
@@ -58,6 +48,8 @@ const Cell = React.memo(
       isPending ? 'word-pending' : '',
       isMatched ? 'word-found' : '',
       isInitial ? 'initial' : '',
+      isPending && pendingDirections.includes('diagonal-down-right') ? 'pending-diag-dr' : '',
+      isPending && pendingDirections.includes('diagonal-up-right') ? 'pending-diag-ur' : '',
     ]
       .filter(Boolean)
       .join(' ');

--- a/src/components/Layout/GameLayout.jsx
+++ b/src/components/Layout/GameLayout.jsx
@@ -36,6 +36,8 @@ function GameLayout({
 
   // Parallel drop tracking
   const [activeDrops, setActiveDrops] = useState([]);
+  // Monotonically increases on each click to key-remount the next-up preview letter
+  const [shiftKey, setShiftKey] = useState(0);
   // Map<column, count> of in-flight drops per column — used to reserve destination rows
   const inFlightColumnsRef = useRef(new Map());
   // Total in-flight drops — used to index into nextLetters for letter assignment
@@ -94,6 +96,7 @@ function GameLayout({
 
     inFlightColumnsRef.current.set(column, columnInFlight + 1);
     inFlightCountRef.current++;
+    setShiftKey(k => k + 1);
 
     setActiveDrops(prev => [...prev, {
       id,
@@ -161,7 +164,7 @@ function GameLayout({
           </div>
         )}
         <div className={previewClasses}>
-          <NextPreview nextLetters={nextLetters.slice(activeDrops.length, activeDrops.length + 5)} visible={showPreview} nextUpRef={nextUpRef} showOrdinals={tutorialStep !== null} />
+          <NextPreview nextLetters={nextLetters.slice(activeDrops.length, activeDrops.length + 5)} visible={showPreview} nextUpRef={nextUpRef} showOrdinals={tutorialStep !== null} shiftKey={shiftKey} />
           <div className={`game-grid-letters-remaining${showPreview ? ' visible' : ''}`}>
             <div className="letters-remaining-label">Letters Remaining</div>
             <div className="letters-remaining-value">{lettersRemaining}</div>

--- a/src/components/Layout/GameLayout.jsx
+++ b/src/components/Layout/GameLayout.jsx
@@ -161,7 +161,7 @@ function GameLayout({
           </div>
         )}
         <div className={previewClasses}>
-          <NextPreview nextLetters={nextLetters} visible={showPreview} nextUpRef={nextUpRef} showOrdinals={tutorialStep !== null} />
+          <NextPreview nextLetters={nextLetters.slice(activeDrops.length, activeDrops.length + 5)} visible={showPreview} nextUpRef={nextUpRef} showOrdinals={tutorialStep !== null} />
           <div className={`game-grid-letters-remaining${showPreview ? ' visible' : ''}`}>
             <div className="letters-remaining-label">Letters Remaining</div>
             <div className="letters-remaining-value">{lettersRemaining}</div>

--- a/src/hooks/useGameLogic.js
+++ b/src/hooks/useGameLogic.js
@@ -14,7 +14,7 @@ const GRAVITY_DELAY_MS = 150;
 
 export function useGameLogic() {
   const { state, dispatch } = useGame();
-  const { dictionary } = useDictionary();
+  const { dictionary, loading } = useDictionary();
 
   // Map<wordKey, { wordData, timerId, idxSet }>
   const pendingRef = useRef(new Map());
@@ -153,5 +153,5 @@ export function useGameLogic() {
     }
   }, [state.grid, state.gameMode, state.status, state.initialBlocks, dispatch]);
 
-  return { dictionary };
+  return { dictionary, loading };
 }

--- a/src/hooks/useTutorial.js
+++ b/src/hooks/useTutorial.js
@@ -100,15 +100,16 @@ export function useTutorial(state, dispatch, onComplete = () => {}) {
     };
   }, [tutorialState, columnIndex]);
 
-  // Auto-advance to TRY_WORD when user drops W during COLUMN step
+  // Auto-advance to TRY_WORD when user drops W during COLUMN step.
+  // DROP_LETTER is dispatched at the END of the drop animation (handleDropComplete),
+  // so state.grid updating here means the letter is already visually settled — no delay needed.
   useEffect(() => {
     if (tutorialState !== 'COLUMN') return;
     const columnHasLetter = state.grid.some(
       (tile, i) => i % GRID_COLS === 0 && tile
     );
     if (columnHasLetter) {
-      const timerId = setTimeout(() => setTutorialState('TRY_WORD'), 600);
-      return () => clearTimeout(timerId);
+      setTutorialState('TRY_WORD');
     }
   }, [state.grid, tutorialState]);
 

--- a/src/hooks/useTutorial.js
+++ b/src/hooks/useTutorial.js
@@ -107,7 +107,8 @@ export function useTutorial(state, dispatch, onComplete = () => {}) {
       (tile, i) => i % GRID_COLS === 0 && tile
     );
     if (columnHasLetter) {
-      setTimeout(() => setTutorialState('TRY_WORD'), 600);
+      const timerId = setTimeout(() => setTutorialState('TRY_WORD'), 600);
+      return () => clearTimeout(timerId);
     }
   }, [state.grid, tutorialState]);
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -360,11 +360,39 @@ body {
     visibility: hidden;
     transition: opacity var(--transition-quick), visibility var(--transition-quick);
     z-index: 1000;
+    transform-origin: top right;
 }
 
 .mode-selection-menu.visible {
     opacity: 1;
     visibility: visible;
+    animation: menuAppear var(--transition-quick) ease-out forwards;
+}
+
+.mode-selection-menu:not(.visible) {
+    animation: menuDisappear var(--transition-quick) ease-in forwards;
+}
+
+@keyframes menuAppear {
+    from {
+        transform: scale(0.3);
+        opacity: 0;
+    }
+    to {
+        transform: scale(1);
+        opacity: 1;
+    }
+}
+
+@keyframes menuDisappear {
+    from {
+        transform: scale(1);
+        opacity: 1;
+    }
+    to {
+        transform: scale(0.3);
+        opacity: 0;
+    }
 }
 
 .mode-selection-content {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -409,23 +409,6 @@ body {
     justify-content: center;
 }
 
-.mode-button-group {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 8px;
-    flex: 1;
-    min-width: 120px;
-}
-
-.mode-description {
-    font-size: clamp(11px, 1.5vw, 13px);
-    color: var(--color-text-secondary);
-    margin: 0;
-    text-align: center;
-    line-height: 1.3;
-}
-
 .mode-selection-btn {
     flex: 1;
     min-width: 120px;
@@ -439,10 +422,27 @@ body {
     text-transform: uppercase;
     letter-spacing: 0.5px;
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
+    gap: 4px;
+}
+
+.btn-title {
+    display: flex;
+    align-items: center;
     gap: 6px;
     white-space: nowrap;
+}
+
+.btn-description {
+    font-size: clamp(11px, 1.5vw, 13px);
+    font-weight: 400;
+    color: inherit;
+    opacity: 0.9;
+    text-transform: none;
+    letter-spacing: normal;
+    line-height: 1.3;
 }
 
 .btn-emoji {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -412,7 +412,7 @@ body {
 .mode-selection-btn {
     flex: 1;
     min-width: 120px;
-    padding: clamp(12px, 2vw, 16px) clamp(16px, 3vw, 24px);
+    padding: clamp(10px, 1.5vw, 12px) clamp(12px, 2.5vw, 18px);
     font-size: clamp(14px, 2.2vw, 18px);
     font-weight: 600;
     border: none;
@@ -425,7 +425,7 @@ body {
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 4px;
+    gap: 2px;
 }
 
 .btn-title {
@@ -443,6 +443,7 @@ body {
     text-transform: none;
     letter-spacing: normal;
     line-height: 1.3;
+    white-space: nowrap;
 }
 
 .btn-emoji {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -46,9 +46,9 @@
 
     /* Word Direction Colors */
     --color-pending-horizontal: var(--color-green);
-    --color-pending-vertical: var(--color-orange-primary);
-    --color-pending-diagonal-down-right: var(--color-blue-primary);
-    --color-pending-diagonal-up-right: #ffffff;
+    --color-pending-vertical: var(--color-blue-primary);
+    --color-pending-diagonal-down-right: #000000;
+    --color-pending-diagonal-up-right: #000000;
 
     /* Sizing */
     --size-letter-block: clamp(30px, 4vw, 38px);

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -381,8 +381,25 @@ body {
     font-size: clamp(20px, 4vw, 28px);
     font-weight: 700;
     color: var(--color-text-primary);
-    margin-bottom: clamp(16px, 3vw, 24px);
+    margin-bottom: clamp(24px, 4vw, 32px);
     letter-spacing: 0.5px;
+}
+
+.mode-selection-section {
+    margin-bottom: clamp(20px, 3vw, 28px);
+}
+
+.mode-selection-section:last-child {
+    margin-bottom: 0;
+}
+
+.mode-selection-section-title {
+    font-size: clamp(12px, 2vw, 14px);
+    font-weight: 600;
+    color: var(--color-text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    margin-bottom: clamp(12px, 2vw, 16px);
 }
 
 .mode-selection-buttons {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -421,6 +421,17 @@ body {
     transition: all var(--transition-quick);
     text-transform: uppercase;
     letter-spacing: 0.5px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    white-space: nowrap;
+}
+
+.btn-emoji {
+    display: inline-block;
+    font-size: 1.2em;
+    margin-left: 4px;
 }
 
 .classic-btn {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -409,6 +409,23 @@ body {
     justify-content: center;
 }
 
+.mode-button-group {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    flex: 1;
+    min-width: 120px;
+}
+
+.mode-description {
+    font-size: clamp(11px, 1.5vw, 13px);
+    color: var(--color-text-secondary);
+    margin: 0;
+    text-align: center;
+    line-height: 1.3;
+}
+
 .mode-selection-btn {
     flex: 1;
     min-width: 120px;

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -45,10 +45,10 @@
     --color-letter-active: var(--color-green);
 
     /* Word Direction Colors */
-    --color-pending-horizontal: var(--color-blue-primary);
+    --color-pending-horizontal: var(--color-green);
     --color-pending-vertical: var(--color-orange-primary);
-    --color-pending-diagonal-down-right: var(--color-green);
-    --color-pending-diagonal-up-right: #9C27B0;
+    --color-pending-diagonal-down-right: var(--color-blue-primary);
+    --color-pending-diagonal-up-right: #ffffff;
 
     /* Sizing */
     --size-letter-block: clamp(30px, 4vw, 38px);

--- a/src/styles/grid.css
+++ b/src/styles/grid.css
@@ -61,7 +61,12 @@
     transition: transform var(--transition-quick);
 }
 
-/* Preview Next-Up (Pulse + Glow effect) */
+/* Preview Next-Up (Pop-in on shift, then continuous pulse + glow) */
+@keyframes previewPop {
+    0%   { transform: scale(1.45); opacity: 0.6; }
+    100% { transform: scale(var(--pulse-scale-start, 1)); opacity: 1; }
+}
+
 .preview-letter-block.next-up {
     --pulse-scale-start: 1.15;
     --pulse-scale-mid: 1.22;
@@ -70,7 +75,10 @@
     background: var(--color-next-up);
     color: var(--color-text-primary);
     box-shadow: var(--shadow-next-up);
-    animation: pulse var(--animation-duration-pulse) ease-in-out infinite;
+    /* On mount: pop in, then settle into the continuous pulse */
+    animation:
+        previewPop 0.15s ease-out,
+        pulse var(--animation-duration-pulse) ease-in-out 0.15s infinite;
 }
 
 /* Empty Preview Letter Block (no letters remaining) - Supersedes next-up styling */

--- a/src/styles/grid.css
+++ b/src/styles/grid.css
@@ -128,6 +128,7 @@
 /* Individual Grid Square - Extends .block-base */
 .grid-square {
     /* Inherit from .block-base: aspect-ratio, flex centering, font-weight, transition, box-sizing */
+    position: relative;
     background: linear-gradient(145deg, var(--color-white), #f5f5f5);
     border: 0.75px solid var(--color-border-light);
     border-radius: var(--size-border-radius-small);
@@ -223,6 +224,34 @@
     100% {
         background-position: 0% 0;
     }
+}
+
+/* Diagonal corner highlights - shared pseudo-element setup */
+.grid-square.pending-diag-dr::before,
+.grid-square.pending-diag-ur::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 2;
+}
+
+/* Diagonal-down-right: top-left corner + bottom-right corner */
+.grid-square.pending-diag-dr::before {
+    background:
+        linear-gradient(to bottom,  var(--color-pending-diagonal-down-right) 8px, transparent 8px) 0 0 / 3px 100% no-repeat,
+        linear-gradient(to right,   var(--color-pending-diagonal-down-right) 8px, transparent 8px) 0 0 / 100% 3px no-repeat,
+        linear-gradient(to top,     var(--color-pending-diagonal-down-right) 8px, transparent 8px) 100% 100% / 3px 100% no-repeat,
+        linear-gradient(to left,    var(--color-pending-diagonal-down-right) 8px, transparent 8px) 0 100% / 100% 3px no-repeat;
+}
+
+/* Diagonal-up-right: top-right corner + bottom-left corner */
+.grid-square.pending-diag-ur::after {
+    background:
+        linear-gradient(to bottom,  var(--color-pending-diagonal-up-right) 8px, transparent 8px) 100% 0 / 3px 100% no-repeat,
+        linear-gradient(to left,    var(--color-pending-diagonal-up-right) 8px, transparent 8px) 0 0 / 100% 3px no-repeat,
+        linear-gradient(to top,     var(--color-pending-diagonal-up-right) 8px, transparent 8px) 0 100% / 3px 100% no-repeat,
+        linear-gradient(to right,   var(--color-pending-diagonal-up-right) 8px, transparent 8px) 0 100% / 100% 3px no-repeat;
 }
 
 /* Grid pulsate animation for user guidance */


### PR DESCRIPTION
### Summary
- Start menu redesign: Redesigned the mode selector into a structured start menu with "Play Game" and "Learn" sections, emoji icons (🕹️ Classic, 🧹 Clear), inline mode descriptions, and a menu button (☰) with shrink/grow animation
- Start menu auto-appears on load while dictionary loads in the background, removing the blocking load screen
- Letter preview reactivity: Preview advances immediately on click with a pop animation when the queue shifts
- Visual polish: Diagonal corner highlights for word detection, improved pending cell styles, and decoupled COLUMN→TRY_WORD transition from arbitrary timeouts