### PR TITLE
POC: How-to-Play Tutorial with Animated Demos

### DIFF
--- a/poc.html
+++ b/poc.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>POC Preview</title>
+</head>
+<body>
+    <div id="poc-root"></div>
+    <script type="module" src="/src/poc.jsx"></script>
+</body>
+</html>

--- a/src/poc.jsx
+++ b/src/poc.jsx
@@ -1,0 +1,17 @@
+import { createRoot } from 'react-dom/client';
+import HomeScreen from './poc/HomeScreen.jsx';
+import './styles/base.css';
+import './styles/card.css';
+
+const container = document.getElementById('poc-root');
+const root = container._root ?? createRoot(container);
+container._root = root;
+root.render(<HomeScreen />);
+
+if (import.meta.hot) {
+  import.meta.hot.accept();
+  import.meta.hot.dispose(() => {
+    root.unmount();
+    container._root = null;
+  });
+}

--- a/src/poc/AnimatedDemo.jsx
+++ b/src/poc/AnimatedDemo.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { COLS, CELL, GAP, STEP, GRID_W } from './constants.js';
+import { COLS, CELL, STEP, GRID_W } from './constants.js';
 import { emptyGrid, destRow, sleep } from './utils.js';
 
 const PREVIEW_SIZE = 5;
@@ -206,21 +206,24 @@ const d = {
   wrapper:      { display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8 },
   previewRow:   { display: 'flex', alignItems: 'center', gap: 5 },
   previewCell:  {
-    width: PCELL, height: PCELL, borderRadius: 6,
-    background: '#9e9e9e', border: '2px solid #757575',
+    width: PCELL, height: PCELL, borderRadius: 7,
+    background: '#888', border: '2px solid #333',
     color: '#fff', fontWeight: 800, fontSize: 16,
     display: 'flex', alignItems: 'center', justifyContent: 'center',
+    boxShadow: '0 4px 8px rgba(0,0,0,0.2)',
     transition: 'transform 0.15s',
   },
   nextUp: {
-    background: 'linear-gradient(145deg, #FFB74D, #FF9800)',
+    background: '#FFB74D',
     borderColor: '#FF9800',
+    color: '#333',
     transform: 'scale(1.15)',
-    boxShadow: '0 4px 12px rgba(255,152,0,0.35)',
+    boxShadow: '0 8px 22px rgba(255,152,0,0.22)',
   },
   emptyCellStyle: {
     background: '#e0e0e0', borderColor: '#bdbdbd',
     color: '#bdbdbd', opacity: 0.4,
+    boxShadow: 'none',
     fontSize: 22,
   },
   cursor: {
@@ -232,30 +235,32 @@ const d = {
   grid: {
     display: 'grid',
     gridTemplateColumns: `repeat(${COLS}, ${CELL}px)`,
-    gap: GAP,
+    gap: 1,
   },
   cell: {
     width: CELL, height: CELL, borderRadius: 6,
-    border: '2px solid #e0e0e0', background: '#f5f5f5',
+    border: '0.75px solid #ddd',
+    background: 'linear-gradient(145deg, #fff, #f5f5f5)',
     display: 'flex', alignItems: 'center', justifyContent: 'center',
     fontSize: 20, fontWeight: 800, color: '#333',
     transition: 'background 0.25s, border-color 0.25s, transform 0.15s',
   },
-  cellFilled:    { background: '#e3f2fd', borderColor: '#90caf9' },
+  cellFilled: {
+    background: '#888', color: '#fff',
+    border: '2px solid #333',
+  },
   cellHighlight: {
-    background: 'linear-gradient(145deg, #a5d6a7, #4CAF50)',
+    background: '#4CAF50',
     borderColor: '#4CAF50', color: '#fff',
-    transform: 'scale(1.06)',
-    boxShadow: '0 2px 8px rgba(76,175,80,0.45)',
+    transform: 'scale(1.05)',
   },
   droppingTile: {
     position: 'absolute',
-    width: CELL, height: CELL, borderRadius: 8,
-    background: 'linear-gradient(145deg, #FFB74D, #FF9800)',
-    border: '2px solid #FF9800', color: '#fff',
+    width: CELL, height: CELL, borderRadius: 6,
+    background: 'linear-gradient(145deg, #e3f2fd, #bbdefb)',
+    border: '2px solid #1976D2', color: '#333',
     fontWeight: 800, fontSize: 20,
     display: 'flex', alignItems: 'center', justifyContent: 'center',
-    boxShadow: '0 4px 12px rgba(255,152,0,0.5)',
     zIndex: 10, willChange: 'top',
   },
   caption: {

--- a/src/poc/AnimatedDemo.jsx
+++ b/src/poc/AnimatedDemo.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { COLS, CELL, GAP, STEP, GRID_W } from './constants.js';
 import { emptyGrid, destRow, sleep } from './utils.js';
 
-function useDemo(panelIdx) {
+function useDemo(demoType) {
   const [vis, setVis] = useState({
     grid:        emptyGrid(),
     preview:     'C',
@@ -72,9 +72,8 @@ function useDemo(panelIdx) {
       await wait(300);
     }
 
-    const panels = [
-      // 0 — Basic dropping
-      async () => {
+    const demos = {
+      drop: async () => {
         while (!signal.aborted) {
           set(s => ({ ...s, grid: emptyGrid(), highlight: null, preview: 'C', caption: 'Click a column to drop the next letter' }));
           await wait(800);
@@ -86,44 +85,50 @@ function useDemo(panelIdx) {
         }
       },
 
-      // 1 — Horizontal word
-      async () => {
+      match: async () => {
         while (!signal.aborted) {
-          set(s => ({ ...s, grid: emptyGrid(), highlight: null, preview: 'C', caption: 'Spell words left to right to score' }));
+          // Horizontal
+          set(s => ({ ...s, grid: emptyGrid(), highlight: null, preview: 'C', caption: 'Spell words left to right' }));
           await wait(800);
           await dropLetter('C', 0, 'A', 'Drop C...');
           await dropLetter('A', 1, 'T', 'Drop A next to it...');
           await dropLetter('T', 2, 'S', 'Complete the word!');
-          await highlightWord([3 * COLS + 0, 3 * COLS + 1, 3 * COLS + 2], '"CAT" — word found! Letters clear.');
-          set(s => ({ ...s, caption: 'Longer words score more points' }));
-          await wait(1000);
-        }
-      },
+          await highlightWord([3 * COLS + 0, 3 * COLS + 1, 3 * COLS + 2], '"CAT" across — word found!');
+          await wait(600);
 
-      // 2 — Vertical word
-      async () => {
-        while (!signal.aborted) {
+          // Vertical
           set(s => ({ ...s, grid: emptyGrid(), highlight: null, preview: 'C', caption: 'Stack letters in a column' }));
           await wait(800);
-          await dropLetter('C', 1, 'A', 'Drop C into column 2...');
-          await dropLetter('A', 1, 'T', 'Same column — it stacks up!');
+          await dropLetter('C', 1, 'A', 'Drop C...');
+          await dropLetter('A', 1, 'T', 'Same column — it stacks!');
           await dropLetter('T', 1, 'S', 'One more...');
-          await highlightWord([1 * COLS + 1, 2 * COLS + 1, 3 * COLS + 1], '"CAT" down — scores the same!');
-          set(s => ({ ...s, caption: 'Mix horizontal and vertical for big scores' }));
-          await wait(1000);
+          await highlightWord([1 * COLS + 1, 2 * COLS + 1, 3 * COLS + 1], '"CAT" down — also scores!');
+          await wait(600);
+
+          // Diagonal
+          set(s => {
+            const grid = emptyGrid();
+            grid[3 * COLS + 0] = 'C';
+            grid[3 * COLS + 1] = 'X';  grid[2 * COLS + 1] = 'A';
+            grid[3 * COLS + 2] = 'X';  grid[2 * COLS + 2] = 'X';  grid[1 * COLS + 2] = 'T';
+            return { ...s, grid, highlight: null, preview: 'S', cursorCol: null, caption: 'Diagonals count too!' };
+          });
+          await wait(800);
+          await highlightWord([3 * COLS + 0, 2 * COLS + 1, 1 * COLS + 2], '"CAT" diagonal — nice!');
+          await wait(600);
         }
       },
-    ];
+    };
 
-    panels[panelIdx]?.().catch(e => { if (e.name !== 'AbortError') console.error(e); });
+    demos[demoType]?.().catch(e => { if (e.name !== 'AbortError') console.error(e); });
     return () => ac.abort();
-  }, [panelIdx]);
+  }, [demoType]);
 
   return vis;
 }
 
-export default function AnimatedDemo({ panelIdx = 0 } = {}) {
-  const { grid, preview, dropping, cursorCol, cursorClick, highlight, caption } = useDemo(panelIdx);
+export default function AnimatedDemo({ demoType = 'drop' } = {}) {
+  const { grid, preview, dropping, cursorCol, cursorClick, highlight, caption } = useDemo(demoType);
 
   return (
     <div style={d.wrapper}>

--- a/src/poc/AnimatedDemo.jsx
+++ b/src/poc/AnimatedDemo.jsx
@@ -1,0 +1,230 @@
+import { useState, useEffect, useRef } from 'react';
+import { COLS, CELL, GAP, STEP, GRID_W } from './constants.js';
+import { emptyGrid, destRow, sleep } from './utils.js';
+
+function useDemo(panelIdx) {
+  const [vis, setVis] = useState({
+    grid:        emptyGrid(),
+    preview:     'C',
+    dropping:    null,
+    cursorCol:   null,
+    cursorClick: false,
+    highlight:   null,
+    caption:     '',
+  });
+
+  const ref = useRef(vis);
+  ref.current = vis;
+
+  useEffect(() => {
+    const ac = new AbortController();
+    const { signal } = ac;
+    const wait = ms => sleep(ms, signal);
+    const get  = () => ref.current;
+    const set  = fn => { if (!signal.aborted) setVis(fn); };
+
+    async function moveCursor(col, caption) {
+      set(s => ({ ...s, cursorCol: col, cursorClick: false, ...(caption ? { caption } : {}) }));
+      await wait(400);
+    }
+
+    async function click() {
+      set(s => ({ ...s, cursorClick: true }));
+      await wait(130);
+      set(s => ({ ...s, cursorClick: false }));
+      await wait(30);
+    }
+
+    async function dropLetter(letter, col, nextPreview, caption) {
+      await moveCursor(col, caption);
+      await click();
+
+      const dr = destRow(get().grid, col);
+      if (dr < 0) return;
+
+      set(s => ({
+        ...s,
+        dropping:  { letter, col, destRow: dr, atTop: true },
+        cursorCol: null,
+        ...(nextPreview ? { preview: nextPreview } : {}),
+      }));
+      await wait(20);
+
+      set(s => s.dropping ? { ...s, dropping: { ...s.dropping, atTop: false } } : s);
+      await wait(400);
+
+      set(s => {
+        const grid = [...s.grid];
+        grid[dr * COLS + col] = letter;
+        return { ...s, grid, dropping: null };
+      });
+      await wait(160);
+    }
+
+    async function highlightWord(indices, caption) {
+      set(s => ({ ...s, highlight: new Set(indices), caption }));
+      await wait(850);
+      set(s => {
+        const grid = [...s.grid];
+        indices.forEach(i => { grid[i] = null; });
+        return { ...s, grid, highlight: null };
+      });
+      await wait(300);
+    }
+
+    const panels = [
+      // 0 — Basic dropping
+      async () => {
+        while (!signal.aborted) {
+          set(s => ({ ...s, grid: emptyGrid(), highlight: null, preview: 'C', caption: 'Click a column to drop the next letter' }));
+          await wait(800);
+          await dropLetter('C', 0, 'A');
+          await dropLetter('A', 3, 'B');
+          await dropLetter('B', 1, 'C');
+          set(s => ({ ...s, caption: 'Letters fall to the lowest empty row' }));
+          await wait(1000);
+        }
+      },
+
+      // 1 — Horizontal word
+      async () => {
+        while (!signal.aborted) {
+          set(s => ({ ...s, grid: emptyGrid(), highlight: null, preview: 'C', caption: 'Spell words left to right to score' }));
+          await wait(800);
+          await dropLetter('C', 0, 'A', 'Drop C...');
+          await dropLetter('A', 1, 'T', 'Drop A next to it...');
+          await dropLetter('T', 2, 'S', 'Complete the word!');
+          await highlightWord([3 * COLS + 0, 3 * COLS + 1, 3 * COLS + 2], '"CAT" — word found! Letters clear.');
+          set(s => ({ ...s, caption: 'Longer words score more points' }));
+          await wait(1000);
+        }
+      },
+
+      // 2 — Vertical word
+      async () => {
+        while (!signal.aborted) {
+          set(s => ({ ...s, grid: emptyGrid(), highlight: null, preview: 'C', caption: 'Stack letters in a column' }));
+          await wait(800);
+          await dropLetter('C', 1, 'A', 'Drop C into column 2...');
+          await dropLetter('A', 1, 'T', 'Same column — it stacks up!');
+          await dropLetter('T', 1, 'S', 'One more...');
+          await highlightWord([1 * COLS + 1, 2 * COLS + 1, 3 * COLS + 1], '"CAT" down — scores the same!');
+          set(s => ({ ...s, caption: 'Mix horizontal and vertical for big scores' }));
+          await wait(1000);
+        }
+      },
+    ];
+
+    panels[panelIdx]?.().catch(e => { if (e.name !== 'AbortError') console.error(e); });
+    return () => ac.abort();
+  }, [panelIdx]);
+
+  return vis;
+}
+
+export default function AnimatedDemo({ panelIdx = 0 } = {}) {
+  const { grid, preview, dropping, cursorCol, cursorClick, highlight, caption } = useDemo(panelIdx);
+
+  return (
+    <div style={d.wrapper}>
+      <div style={d.previewRow}>
+        <span style={d.previewLabel}>Next</span>
+        <div style={d.previewCell}>{preview}</div>
+      </div>
+
+      <div style={{ position: 'relative', width: GRID_W, height: 22 }}>
+        {cursorCol !== null && (
+          <div style={{
+            ...d.cursor,
+            left: cursorCol * STEP + (CELL - 16) / 2,
+            transform: cursorClick ? 'scale(0.65)' : 'scale(1)',
+          }}>
+            ▼
+          </div>
+        )}
+      </div>
+
+      <div style={{ position: 'relative', width: GRID_W, overflow: 'visible' }}>
+        <div style={d.grid}>
+          {grid.map((letter, i) => (
+            <div
+              key={i}
+              style={{
+                ...d.cell,
+                ...(letter ? d.cellFilled : {}),
+                ...(highlight?.has(i) ? d.cellHighlight : {}),
+              }}
+            >
+              {letter ?? ''}
+            </div>
+          ))}
+        </div>
+
+        {dropping && (
+          <div style={{
+            ...d.droppingTile,
+            left: dropping.col * STEP,
+            top:  dropping.atTop ? -(STEP + 6) : dropping.destRow * STEP,
+            transition: dropping.atTop ? 'none' : 'top 0.38s ease-in',
+          }}>
+            {dropping.letter}
+          </div>
+        )}
+      </div>
+
+      <p style={d.caption}>{caption || '\u00a0'}</p>
+    </div>
+  );
+}
+
+const d = {
+  wrapper:      { display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8 },
+  previewRow:   { display: 'flex', alignItems: 'center', gap: 8 },
+  previewLabel: { fontSize: 11, color: '#888', textTransform: 'uppercase', letterSpacing: '0.08em' },
+  previewCell:  {
+    width: CELL, height: CELL,
+    background: 'linear-gradient(145deg, #FFB74D, #FF9800)',
+    color: '#fff', fontWeight: 800, fontSize: 20,
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    borderRadius: 8, boxShadow: '0 2px 6px rgba(255,152,0,0.4)',
+  },
+  cursor: {
+    position: 'absolute', top: 2,
+    fontSize: 16, color: '#1976D2',
+    transition: 'left 0.3s ease-out, transform 0.1s ease',
+    userSelect: 'none', lineHeight: 1,
+  },
+  grid: {
+    display: 'grid',
+    gridTemplateColumns: `repeat(${COLS}, ${CELL}px)`,
+    gap: GAP,
+  },
+  cell: {
+    width: CELL, height: CELL, borderRadius: 6,
+    border: '2px solid #e0e0e0', background: '#f5f5f5',
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    fontSize: 20, fontWeight: 800, color: '#333',
+    transition: 'background 0.25s, border-color 0.25s, transform 0.15s',
+  },
+  cellFilled:    { background: '#e3f2fd', borderColor: '#90caf9' },
+  cellHighlight: {
+    background: 'linear-gradient(145deg, #a5d6a7, #4CAF50)',
+    borderColor: '#4CAF50', color: '#fff',
+    transform: 'scale(1.06)',
+    boxShadow: '0 2px 8px rgba(76,175,80,0.45)',
+  },
+  droppingTile: {
+    position: 'absolute',
+    width: CELL, height: CELL, borderRadius: 8,
+    background: 'linear-gradient(145deg, #FFB74D, #FF9800)',
+    border: '2px solid #FF9800', color: '#fff',
+    fontWeight: 800, fontSize: 20,
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    boxShadow: '0 4px 12px rgba(255,152,0,0.5)',
+    zIndex: 10, willChange: 'top',
+  },
+  caption: {
+    fontSize: 13, color: '#555', textAlign: 'center',
+    minHeight: 36, maxWidth: 220, lineHeight: 1.4, margin: 0,
+  },
+};

--- a/src/poc/AnimatedDemo.jsx
+++ b/src/poc/AnimatedDemo.jsx
@@ -77,6 +77,21 @@ function useDemo(demoType) {
     }
 
     const demos = {
+      queue: async () => {
+        while (!signal.aborted) {
+          set(s => ({ ...s, grid: emptyGrid(), highlight: null, queue: ['C', 'A', 'T', 'S', 'B'], caption: 'The first letter is next to drop' }));
+          await wait(1200);
+          await dropLetter(0, 'C drops — queue shifts left');
+          await wait(600);
+          set(s => ({ ...s, caption: 'A is now next, then T, S, B...' }));
+          await wait(1200);
+          await dropLetter(1, 'A drops — queue shifts again');
+          await wait(600);
+          set(s => ({ ...s, caption: 'Plan ahead using the queue!' }));
+          await wait(1500);
+        }
+      },
+
       drop: async () => {
         while (!signal.aborted) {
           set(s => ({ ...s, grid: emptyGrid(), highlight: null, queue: ['C', 'A', 'B', 'C', 'A'], caption: 'Click a column to drop the next letter' }));

--- a/src/poc/AnimatedDemo.jsx
+++ b/src/poc/AnimatedDemo.jsx
@@ -94,13 +94,14 @@ function useDemo(demoType) {
 
       drop: async () => {
         while (!signal.aborted) {
-          set(s => ({ ...s, grid: emptyGrid(), highlight: null, queue: ['C', 'A', 'B', 'C', 'A'], caption: 'Click a column to drop the next letter' }));
+          set(s => ({ ...s, grid: emptyGrid(), highlight: null, queue: ['C', 'A', 'B', 'T', 'S'], caption: 'Click a column to drop the next letter' }));
           await wait(800);
-          await dropLetter(0);
+          await dropLetter(1, 'Letters fall to the lowest empty row');
           await dropLetter(3);
-          await dropLetter(1);
-          set(s => ({ ...s, caption: 'Letters fall to the lowest empty row' }));
-          await wait(1000);
+          await dropLetter(1, 'Same column — it stacks on top!');
+          await dropLetter(1, 'Letters keep stacking up');
+          set(s => ({ ...s, caption: 'Plan your columns carefully!' }));
+          await wait(1200);
         }
       },
 

--- a/src/poc/AnimatedDemo.jsx
+++ b/src/poc/AnimatedDemo.jsx
@@ -107,35 +107,37 @@ function useDemo(demoType) {
 
       match: async () => {
         while (!signal.aborted) {
-          // Horizontal
-          set(s => ({ ...s, grid: emptyGrid(), highlight: null, queue: ['C', 'A', 'T', 'S', 'B'], caption: 'Spell words left to right' }));
+          const fullQueue = ['C', 'A', 'T', 'G', 'O', 'D', 'X', 'Y', 'Z', 'T', 'C', 'A'];
+          set(s => ({ ...s, grid: emptyGrid(), highlight: null, queue: fullQueue, caption: 'Spell words left to right' }));
           await wait(800);
+
+          // Horizontal CAT
           await dropLetter(0, 'Drop C...');
           await dropLetter(1, 'Drop A next to it...');
           await dropLetter(2, 'Complete the word!');
           await highlightWord([3 * COLS + 0, 3 * COLS + 1, 3 * COLS + 2], '"CAT" across — word found!');
           await wait(600);
 
-          // Vertical
-          set(s => ({ ...s, grid: emptyGrid(), highlight: null, queue: ['C', 'A', 'T', 'S', 'B'], caption: 'Stack letters in a column' }));
-          await wait(800);
-          await dropLetter(1, 'Drop C...');
-          await dropLetter(1, 'Same column — it stacks!');
-          await dropLetter(1, 'One more...');
-          await highlightWord([1 * COLS + 1, 2 * COLS + 1, 3 * COLS + 1], '"CAT" down — also scores!');
+          // Vertical DOG
+          set(s => ({ ...s, caption: 'Now stack letters vertically' }));
+          await wait(600);
+          await dropLetter(3, 'Drop G...');
+          await dropLetter(3, 'Stack O on top...');
+          await dropLetter(3, 'D completes the column!');
+          await highlightWord([1 * COLS + 3, 2 * COLS + 3, 3 * COLS + 3], '"DOG" down — vertical match!');
           await wait(600);
 
-          // Diagonal
-          set(s => {
-            const grid = emptyGrid();
-            grid[3 * COLS + 0] = 'C';
-            grid[3 * COLS + 1] = 'X';  grid[2 * COLS + 1] = 'A';
-            grid[3 * COLS + 2] = 'X';  grid[2 * COLS + 2] = 'X';  grid[1 * COLS + 2] = 'T';
-            return { ...s, grid, highlight: null, queue: ['S', 'B', 'E', 'D', 'A'], cursorCol: null, caption: 'Diagonals count too!' };
-          });
-          await wait(800);
-          await highlightWord([3 * COLS + 0, 2 * COLS + 1, 1 * COLS + 2], '"CAT" diagonal — nice!');
+          // Diagonal CAT — build support letters then the diagonal
+          set(s => ({ ...s, caption: 'Build up for a diagonal' }));
           await wait(600);
+          await dropLetter(0);                              // X → (3,0)
+          await dropLetter(0);                              // Y → (2,0)
+          await dropLetter(1);                              // Z → (3,1)
+          await dropLetter(2, 'Place the diagonal letters...');  // T → (3,2)
+          await dropLetter(0, 'C on top...');               // C → (1,0)
+          await dropLetter(1, 'A completes the diagonal!'); // A → (2,1)
+          await highlightWord([1 * COLS + 0, 2 * COLS + 1, 3 * COLS + 2], '"CAT" diagonal — nice!');
+          await wait(1000);
         }
       },
     };

--- a/src/poc/AnimatedDemo.jsx
+++ b/src/poc/AnimatedDemo.jsx
@@ -2,10 +2,13 @@ import { useState, useEffect, useRef } from 'react';
 import { COLS, CELL, GAP, STEP, GRID_W } from './constants.js';
 import { emptyGrid, destRow, sleep } from './utils.js';
 
+const PREVIEW_SIZE = 5;
+const PCELL = 36;
+
 function useDemo(demoType) {
   const [vis, setVis] = useState({
     grid:        emptyGrid(),
-    preview:     'C',
+    queue:       ['C', 'A', 'B', 'C', 'A'],
     dropping:    null,
     cursorCol:   null,
     cursorClick: false,
@@ -35,7 +38,8 @@ function useDemo(demoType) {
       await wait(30);
     }
 
-    async function dropLetter(letter, col, nextPreview, caption) {
+    async function dropLetter(col, caption) {
+      const letter = get().queue[0];
       await moveCursor(col, caption);
       await click();
 
@@ -46,7 +50,7 @@ function useDemo(demoType) {
         ...s,
         dropping:  { letter, col, destRow: dr, atTop: true },
         cursorCol: null,
-        ...(nextPreview ? { preview: nextPreview } : {}),
+        queue: s.queue.slice(1),
       }));
       await wait(20);
 
@@ -75,11 +79,11 @@ function useDemo(demoType) {
     const demos = {
       drop: async () => {
         while (!signal.aborted) {
-          set(s => ({ ...s, grid: emptyGrid(), highlight: null, preview: 'C', caption: 'Click a column to drop the next letter' }));
+          set(s => ({ ...s, grid: emptyGrid(), highlight: null, queue: ['C', 'A', 'B', 'C', 'A'], caption: 'Click a column to drop the next letter' }));
           await wait(800);
-          await dropLetter('C', 0, 'A');
-          await dropLetter('A', 3, 'B');
-          await dropLetter('B', 1, 'C');
+          await dropLetter(0);
+          await dropLetter(3);
+          await dropLetter(1);
           set(s => ({ ...s, caption: 'Letters fall to the lowest empty row' }));
           await wait(1000);
         }
@@ -88,20 +92,20 @@ function useDemo(demoType) {
       match: async () => {
         while (!signal.aborted) {
           // Horizontal
-          set(s => ({ ...s, grid: emptyGrid(), highlight: null, preview: 'C', caption: 'Spell words left to right' }));
+          set(s => ({ ...s, grid: emptyGrid(), highlight: null, queue: ['C', 'A', 'T', 'S', 'B'], caption: 'Spell words left to right' }));
           await wait(800);
-          await dropLetter('C', 0, 'A', 'Drop C...');
-          await dropLetter('A', 1, 'T', 'Drop A next to it...');
-          await dropLetter('T', 2, 'S', 'Complete the word!');
+          await dropLetter(0, 'Drop C...');
+          await dropLetter(1, 'Drop A next to it...');
+          await dropLetter(2, 'Complete the word!');
           await highlightWord([3 * COLS + 0, 3 * COLS + 1, 3 * COLS + 2], '"CAT" across — word found!');
           await wait(600);
 
           // Vertical
-          set(s => ({ ...s, grid: emptyGrid(), highlight: null, preview: 'C', caption: 'Stack letters in a column' }));
+          set(s => ({ ...s, grid: emptyGrid(), highlight: null, queue: ['C', 'A', 'T', 'S', 'B'], caption: 'Stack letters in a column' }));
           await wait(800);
-          await dropLetter('C', 1, 'A', 'Drop C...');
-          await dropLetter('A', 1, 'T', 'Same column — it stacks!');
-          await dropLetter('T', 1, 'S', 'One more...');
+          await dropLetter(1, 'Drop C...');
+          await dropLetter(1, 'Same column — it stacks!');
+          await dropLetter(1, 'One more...');
           await highlightWord([1 * COLS + 1, 2 * COLS + 1, 3 * COLS + 1], '"CAT" down — also scores!');
           await wait(600);
 
@@ -111,7 +115,7 @@ function useDemo(demoType) {
             grid[3 * COLS + 0] = 'C';
             grid[3 * COLS + 1] = 'X';  grid[2 * COLS + 1] = 'A';
             grid[3 * COLS + 2] = 'X';  grid[2 * COLS + 2] = 'X';  grid[1 * COLS + 2] = 'T';
-            return { ...s, grid, highlight: null, preview: 'S', cursorCol: null, caption: 'Diagonals count too!' };
+            return { ...s, grid, highlight: null, queue: ['S', 'B', 'E', 'D', 'A'], cursorCol: null, caption: 'Diagonals count too!' };
           });
           await wait(800);
           await highlightWord([3 * COLS + 0, 2 * COLS + 1, 1 * COLS + 2], '"CAT" diagonal — nice!');
@@ -128,13 +132,29 @@ function useDemo(demoType) {
 }
 
 export default function AnimatedDemo({ demoType = 'drop' } = {}) {
-  const { grid, preview, dropping, cursorCol, cursorClick, highlight, caption } = useDemo(demoType);
+  const { grid, queue, dropping, cursorCol, cursorClick, highlight, caption } = useDemo(demoType);
 
   return (
     <div style={d.wrapper}>
+      {/* 5-letter preview queue */}
       <div style={d.previewRow}>
-        <span style={d.previewLabel}>Next</span>
-        <div style={d.previewCell}>{preview}</div>
+        {Array(PREVIEW_SIZE).fill(null).map((_, i) => {
+          const letter = queue[i];
+          const isNextUp = i === 0 && letter;
+          const isEmpty = !letter;
+          return (
+            <div
+              key={i}
+              style={{
+                ...d.previewCell,
+                ...(isNextUp ? d.nextUp : {}),
+                ...(isEmpty ? d.emptyCellStyle : {}),
+              }}
+            >
+              {isEmpty ? '\u2014' : letter}
+            </div>
+          );
+        })}
       </div>
 
       <div style={{ position: 'relative', width: GRID_W, height: 22 }}>
@@ -184,14 +204,24 @@ export default function AnimatedDemo({ demoType = 'drop' } = {}) {
 
 const d = {
   wrapper:      { display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8 },
-  previewRow:   { display: 'flex', alignItems: 'center', gap: 8 },
-  previewLabel: { fontSize: 11, color: '#888', textTransform: 'uppercase', letterSpacing: '0.08em' },
+  previewRow:   { display: 'flex', alignItems: 'center', gap: 5 },
   previewCell:  {
-    width: CELL, height: CELL,
-    background: 'linear-gradient(145deg, #FFB74D, #FF9800)',
-    color: '#fff', fontWeight: 800, fontSize: 20,
+    width: PCELL, height: PCELL, borderRadius: 6,
+    background: '#9e9e9e', border: '2px solid #757575',
+    color: '#fff', fontWeight: 800, fontSize: 16,
     display: 'flex', alignItems: 'center', justifyContent: 'center',
-    borderRadius: 8, boxShadow: '0 2px 6px rgba(255,152,0,0.4)',
+    transition: 'transform 0.15s',
+  },
+  nextUp: {
+    background: 'linear-gradient(145deg, #FFB74D, #FF9800)',
+    borderColor: '#FF9800',
+    transform: 'scale(1.15)',
+    boxShadow: '0 4px 12px rgba(255,152,0,0.35)',
+  },
+  emptyCellStyle: {
+    background: '#e0e0e0', borderColor: '#bdbdbd',
+    color: '#bdbdbd', opacity: 0.4,
+    fontSize: 22,
   },
   cursor: {
     position: 'absolute', top: 2,

--- a/src/poc/HomeScreen.jsx
+++ b/src/poc/HomeScreen.jsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import HowToPlayModal from './HowToPlayModal.jsx';
+
+export default function HomeScreen() {
+  const [showHTP, setShowHTP] = useState(false);
+
+  return (
+    <div style={h.page}>
+      <div className="card" style={h.card}>
+        <h1 style={h.title}>NOODLE</h1>
+        <p style={h.desc}>a word puzzle game</p>
+        <div style={h.btns}>
+          <button className="start-btn"    title="Play"         onClick={() => alert('Play!')}>&#9654;</button>
+          <button className="settings-btn" title="Settings"     onClick={() => alert('Settings!')}>&#9881;</button>
+          <button style={h.htpBtn}         title="How to play"  onClick={() => setShowHTP(true)}>?</button>
+        </div>
+      </div>
+
+      {showHTP && <HowToPlayModal onClose={() => setShowHTP(false)} />}
+    </div>
+  );
+}
+
+const h = {
+  page: {
+    minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center',
+    background: 'linear-gradient(135deg, #e3f2fd 0%, #f8f9fa 100%)',
+    fontFamily: 'system-ui, sans-serif',
+  },
+  card: {
+    display: 'flex', flexDirection: 'column', alignItems: 'center',
+    gap: 16, padding: '32px 40px', minWidth: 260,
+  },
+  title: { fontSize: 'clamp(32px,8vw,56px)', fontWeight: 800, letterSpacing: '0.05em', color: 'var(--color-text-primary)', margin: 0 },
+  desc:  { fontSize: 'clamp(13px,2vw,16px)', color: 'var(--color-text-secondary)', margin: 0 },
+  btns:  { display: 'flex', flexDirection: 'row', gap: 12, marginTop: 8 },
+  htpBtn: {
+    width: 'var(--size-letter-block)', height: 'var(--size-letter-block)', aspectRatio: '1/1',
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    background: 'linear-gradient(145deg, #a5d6a7, #4CAF50)', color: '#fff',
+    border: 'none', borderRadius: 8, fontSize: 'clamp(16px,2vw,20px)',
+    fontWeight: 'bold', cursor: 'pointer', boxShadow: '0 2px 6px rgba(76,175,80,0.3)',
+  },
+};

--- a/src/poc/HowToPlayModal.jsx
+++ b/src/poc/HowToPlayModal.jsx
@@ -1,48 +1,27 @@
-import { useState } from 'react';
 import AnimatedDemo from './AnimatedDemo.jsx';
-import { PANEL_TITLES } from './constants.js';
+import { STEPS } from './constants.js';
 
 export default function HowToPlayModal({ onClose = () => {} } = {}) {
-  const [panelIdx, setPanelIdx] = useState(0);
-  const total = PANEL_TITLES.length;
-
   return (
     <div style={m.backdrop} onClick={onClose}>
       <div style={m.modal} onClick={e => e.stopPropagation()}>
 
-        <div style={m.header}>
-          <h2 style={m.title}>How to Play</h2>
-          <span style={m.pageNum}>{panelIdx + 1} / {total}</span>
+        <h2 style={m.title}>How to Play</h2>
+
+        <div style={m.scrollArea}>
+          {STEPS.map(step => (
+            <div key={step.number} style={m.step}>
+              <div style={m.stepHeader}>
+                <span style={m.stepNumber}>{step.number}</span>
+                <span style={m.stepTitle}>{step.title}</span>
+              </div>
+              <p style={m.stepDesc}>{step.description}</p>
+              <AnimatedDemo demoType={step.demoType} />
+            </div>
+          ))}
         </div>
 
-        <p style={m.subtitle}>{PANEL_TITLES[panelIdx]}</p>
-
-        <AnimatedDemo key={panelIdx} panelIdx={panelIdx} />
-
-        <div style={m.nav}>
-          <button
-            style={{ ...m.navBtn, opacity: panelIdx === 0 ? 0.3 : 1 }}
-            disabled={panelIdx === 0}
-            onClick={() => setPanelIdx(i => i - 1)}
-          >&#8249;</button>
-
-          <div style={m.dots}>
-            {PANEL_TITLES.map((_, i) => (
-              <div
-                key={i}
-                style={{ ...m.dot, ...(i === panelIdx ? m.dotActive : {}) }}
-                onClick={() => setPanelIdx(i)}
-              />
-            ))}
-          </div>
-
-          <button
-            style={{ ...m.navBtn, ...(panelIdx === total - 1 ? m.doneBtn : {}) }}
-            onClick={() => panelIdx === total - 1 ? onClose() : setPanelIdx(i => i + 1)}
-          >
-            {panelIdx === total - 1 ? 'Got it' : '\u203A'}
-          </button>
-        </div>
+        <button style={m.gotItBtn} onClick={onClose}>Got it</button>
 
       </div>
     </div>
@@ -56,24 +35,39 @@ const m = {
   },
   modal: {
     background: '#fff', borderRadius: 16, padding: '24px 24px 20px',
-    maxWidth: 300, width: '92%',
+    maxWidth: 340, width: '92%', maxHeight: '85vh',
     boxShadow: '0 12px 40px rgba(0,0,0,0.25)',
     display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12,
   },
-  header:  { display: 'flex', justifyContent: 'space-between', alignItems: 'center', width: '100%' },
-  title:   { fontSize: 20, fontWeight: 700, color: '#333', margin: 0 },
-  pageNum: { fontSize: 12, color: '#999' },
-  subtitle:{ fontSize: 12, fontWeight: 600, color: '#1976D2', textTransform: 'uppercase', letterSpacing: '0.06em', margin: 0, alignSelf: 'flex-start' },
-  nav:     { display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%', marginTop: 4 },
-  navBtn:  {
-    width: 40, height: 40, borderRadius: 8,
-    border: '2px solid #e0e0e0', background: '#fff',
-    fontSize: 22, cursor: 'pointer', color: '#333',
-    display: 'flex', alignItems: 'center', justifyContent: 'center',
-    transition: 'background 0.15s',
+  title: { fontSize: 20, fontWeight: 700, color: '#333', margin: 0 },
+  scrollArea: {
+    overflowY: 'auto', flex: 1, width: '100%',
+    display: 'flex', flexDirection: 'column', gap: 24,
   },
-  doneBtn: { width: 'auto', padding: '0 16px', fontSize: 14, fontWeight: 600, background: '#1976D2', color: '#fff', border: 'none' },
-  dots:    { display: 'flex', gap: 6, alignItems: 'center' },
-  dot:     { width: 8, height: 8, borderRadius: '50%', background: '#ddd', cursor: 'pointer', transition: 'background 0.2s' },
-  dotActive: { background: '#1976D2' },
+  step: {
+    display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8,
+  },
+  stepHeader: {
+    display: 'flex', alignItems: 'center', gap: 8,
+  },
+  stepNumber: {
+    width: 24, height: 24, borderRadius: '50%',
+    background: '#1976D2', color: '#fff',
+    fontSize: 13, fontWeight: 700,
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+  },
+  stepTitle: {
+    fontSize: 14, fontWeight: 700, color: '#1976D2',
+    textTransform: 'uppercase', letterSpacing: '0.06em',
+  },
+  stepDesc: {
+    fontSize: 13, color: '#555', textAlign: 'center',
+    lineHeight: 1.4, margin: 0, maxWidth: 260,
+  },
+  gotItBtn: {
+    width: '100%', padding: '10px 0', borderRadius: 8,
+    background: '#1976D2', color: '#fff', border: 'none',
+    fontSize: 14, fontWeight: 600, cursor: 'pointer',
+    marginTop: 4,
+  },
 };

--- a/src/poc/HowToPlayModal.jsx
+++ b/src/poc/HowToPlayModal.jsx
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+import AnimatedDemo from './AnimatedDemo.jsx';
+import { PANEL_TITLES } from './constants.js';
+
+export default function HowToPlayModal({ onClose = () => {} } = {}) {
+  const [panelIdx, setPanelIdx] = useState(0);
+  const total = PANEL_TITLES.length;
+
+  return (
+    <div style={m.backdrop} onClick={onClose}>
+      <div style={m.modal} onClick={e => e.stopPropagation()}>
+
+        <div style={m.header}>
+          <h2 style={m.title}>How to Play</h2>
+          <span style={m.pageNum}>{panelIdx + 1} / {total}</span>
+        </div>
+
+        <p style={m.subtitle}>{PANEL_TITLES[panelIdx]}</p>
+
+        <AnimatedDemo key={panelIdx} panelIdx={panelIdx} />
+
+        <div style={m.nav}>
+          <button
+            style={{ ...m.navBtn, opacity: panelIdx === 0 ? 0.3 : 1 }}
+            disabled={panelIdx === 0}
+            onClick={() => setPanelIdx(i => i - 1)}
+          >&#8249;</button>
+
+          <div style={m.dots}>
+            {PANEL_TITLES.map((_, i) => (
+              <div
+                key={i}
+                style={{ ...m.dot, ...(i === panelIdx ? m.dotActive : {}) }}
+                onClick={() => setPanelIdx(i)}
+              />
+            ))}
+          </div>
+
+          <button
+            style={{ ...m.navBtn, ...(panelIdx === total - 1 ? m.doneBtn : {}) }}
+            onClick={() => panelIdx === total - 1 ? onClose() : setPanelIdx(i => i + 1)}
+          >
+            {panelIdx === total - 1 ? 'Got it' : '\u203A'}
+          </button>
+        </div>
+
+      </div>
+    </div>
+  );
+}
+
+const m = {
+  backdrop: {
+    position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.45)',
+    display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 100,
+  },
+  modal: {
+    background: '#fff', borderRadius: 16, padding: '24px 24px 20px',
+    maxWidth: 300, width: '92%',
+    boxShadow: '0 12px 40px rgba(0,0,0,0.25)',
+    display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12,
+  },
+  header:  { display: 'flex', justifyContent: 'space-between', alignItems: 'center', width: '100%' },
+  title:   { fontSize: 20, fontWeight: 700, color: '#333', margin: 0 },
+  pageNum: { fontSize: 12, color: '#999' },
+  subtitle:{ fontSize: 12, fontWeight: 600, color: '#1976D2', textTransform: 'uppercase', letterSpacing: '0.06em', margin: 0, alignSelf: 'flex-start' },
+  nav:     { display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%', marginTop: 4 },
+  navBtn:  {
+    width: 40, height: 40, borderRadius: 8,
+    border: '2px solid #e0e0e0', background: '#fff',
+    fontSize: 22, cursor: 'pointer', color: '#333',
+    display: 'flex', alignItems: 'center', justifyContent: 'center',
+    transition: 'background 0.15s',
+  },
+  doneBtn: { width: 'auto', padding: '0 16px', fontSize: 14, fontWeight: 600, background: '#1976D2', color: '#fff', border: 'none' },
+  dots:    { display: 'flex', gap: 6, alignItems: 'center' },
+  dot:     { width: 8, height: 8, borderRadius: '50%', background: '#ddd', cursor: 'pointer', transition: 'background 0.2s' },
+  dotActive: { background: '#1976D2' },
+};

--- a/src/poc/HowToPlayModal.jsx
+++ b/src/poc/HowToPlayModal.jsx
@@ -1,14 +1,19 @@
+import { useState } from 'react';
 import AnimatedDemo from './AnimatedDemo.jsx';
 import { STEPS } from './constants.js';
 
 export default function HowToPlayModal({ onClose = () => {} } = {}) {
+  const [exampleIdx, setExampleIdx] = useState(0);
+  const current = STEPS[exampleIdx];
+
   return (
     <div style={m.backdrop} onClick={onClose}>
       <div style={m.modal} onClick={e => e.stopPropagation()}>
 
         <h2 style={m.title}>How to Play</h2>
 
-        <div style={m.scrollArea}>
+        {/* Steps (text only) */}
+        <div style={m.steps}>
           {STEPS.map(step => (
             <div key={step.number} style={m.step}>
               <div style={m.stepHeader}>
@@ -16,9 +21,28 @@ export default function HowToPlayModal({ onClose = () => {} } = {}) {
                 <span style={m.stepTitle}>{step.title}</span>
               </div>
               <p style={m.stepDesc}>{step.description}</p>
-              <AnimatedDemo demoType={step.demoType} />
             </div>
           ))}
+        </div>
+
+        {/* Divider */}
+        <hr style={m.divider} />
+
+        {/* Examples panel */}
+        <div style={m.exampleSection}>
+          <div style={m.exampleTabs}>
+            {STEPS.map((step, i) => (
+              <button
+                key={i}
+                style={{ ...m.tab, ...(i === exampleIdx ? m.tabActive : {}) }}
+                onClick={() => setExampleIdx(i)}
+              >
+                {step.title}
+              </button>
+            ))}
+          </div>
+
+          <AnimatedDemo key={exampleIdx} demoType={current.demoType} />
         </div>
 
         <button style={m.gotItBtn} onClick={onClose}>Got it</button>
@@ -38,31 +62,54 @@ const m = {
     maxWidth: 340, width: '92%', maxHeight: '85vh',
     boxShadow: '0 12px 40px rgba(0,0,0,0.25)',
     display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12,
+    overflowY: 'auto',
   },
   title: { fontSize: 20, fontWeight: 700, color: '#333', margin: 0 },
-  scrollArea: {
-    overflowY: 'auto', flex: 1, width: '100%',
-    display: 'flex', flexDirection: 'column', gap: 24,
+  steps: {
+    width: '100%', display: 'flex', flexDirection: 'column', gap: 16,
   },
   step: {
-    display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8,
+    display: 'flex', flexDirection: 'column', gap: 4,
   },
   stepHeader: {
     display: 'flex', alignItems: 'center', gap: 8,
   },
   stepNumber: {
-    width: 24, height: 24, borderRadius: '50%',
+    width: 22, height: 22, borderRadius: '50%',
     background: '#1976D2', color: '#fff',
-    fontSize: 13, fontWeight: 700,
+    fontSize: 12, fontWeight: 700,
     display: 'flex', alignItems: 'center', justifyContent: 'center',
+    flexShrink: 0,
   },
   stepTitle: {
     fontSize: 14, fontWeight: 700, color: '#1976D2',
     textTransform: 'uppercase', letterSpacing: '0.06em',
   },
   stepDesc: {
-    fontSize: 13, color: '#555', textAlign: 'center',
-    lineHeight: 1.4, margin: 0, maxWidth: 260,
+    fontSize: 13, color: '#555', lineHeight: 1.4,
+    margin: '0 0 0 30px',
+  },
+  divider: {
+    width: '100%', border: 'none',
+    borderTop: '1px solid #e0e0e0', margin: '4px 0',
+  },
+  exampleSection: {
+    width: '100%', display: 'flex', flexDirection: 'column',
+    alignItems: 'center', gap: 12,
+  },
+  exampleTabs: {
+    display: 'flex', gap: 0, borderRadius: 8, overflow: 'hidden',
+    border: '2px solid #1976D2',
+  },
+  tab: {
+    padding: '6px 20px', fontSize: 12, fontWeight: 600,
+    textTransform: 'uppercase', letterSpacing: '0.04em',
+    border: 'none', cursor: 'pointer',
+    background: '#fff', color: '#1976D2',
+    transition: 'background 0.15s, color 0.15s',
+  },
+  tabActive: {
+    background: '#1976D2', color: '#fff',
   },
   gotItBtn: {
     width: '100%', padding: '10px 0', borderRadius: 8,

--- a/src/poc/constants.js
+++ b/src/poc/constants.js
@@ -6,6 +6,7 @@ export const STEP = CELL + GAP;
 export const GRID_W = COLS * CELL + (COLS - 1) * GAP;
 
 export const STEPS = [
-  { number: 1, title: 'DROP', description: 'Click a column to place the Preview Letter. It always falls to the lowest empty space.', demoType: 'drop' },
-  { number: 2, title: 'MATCH', description: 'Form words horizontally, vertically, or diagonally.', demoType: 'match' },
+  { number: 1, title: 'QUEUE', description: 'Letters arrive in order from left to right\u2014use the preview to set up your next move.', demoType: 'queue' },
+  { number: 2, title: 'DROP', description: 'Click a column to place the Preview Letter. It always falls to the lowest empty space.', demoType: 'drop' },
+  { number: 3, title: 'MATCH', description: 'Form words horizontally, vertically, or diagonally.', demoType: 'match' },
 ];

--- a/src/poc/constants.js
+++ b/src/poc/constants.js
@@ -5,4 +5,7 @@ export const GAP = 4;
 export const STEP = CELL + GAP;
 export const GRID_W = COLS * CELL + (COLS - 1) * GAP;
 
-export const PANEL_TITLES = ['Dropping letters', 'Words across', 'Words down'];
+export const STEPS = [
+  { number: 1, title: 'DROP', description: 'Click a column to place the Preview Letter. It always falls to the lowest empty space.', demoType: 'drop' },
+  { number: 2, title: 'MATCH', description: 'Form words horizontally, vertically, or diagonally.', demoType: 'match' },
+];

--- a/src/poc/constants.js
+++ b/src/poc/constants.js
@@ -1,7 +1,7 @@
 export const COLS = 4;
 export const ROWS = 4;
 export const CELL = 48;
-export const GAP = 4;
+export const GAP = 1;
 export const STEP = CELL + GAP;
 export const GRID_W = COLS * CELL + (COLS - 1) * GAP;
 

--- a/src/poc/constants.js
+++ b/src/poc/constants.js
@@ -1,0 +1,8 @@
+export const COLS = 4;
+export const ROWS = 4;
+export const CELL = 48;
+export const GAP = 4;
+export const STEP = CELL + GAP;
+export const GRID_W = COLS * CELL + (COLS - 1) * GAP;
+
+export const PANEL_TITLES = ['Dropping letters', 'Words across', 'Words down'];

--- a/src/poc/utils.js
+++ b/src/poc/utils.js
@@ -1,0 +1,19 @@
+import { ROWS, COLS } from './constants.js';
+
+export function emptyGrid() {
+  return Array(ROWS * COLS).fill(null);
+}
+
+export function destRow(grid, col) {
+  for (let r = ROWS - 1; r >= 0; r--)
+    if (!grid[r * COLS + col]) return r;
+  return -1;
+}
+
+export function sleep(ms, signal) {
+  return new Promise((res, rej) => {
+    if (signal.aborted) return rej(new DOMException('Aborted', 'AbortError'));
+    const id = setTimeout(res, ms);
+    signal.addEventListener('abort', () => { clearTimeout(id); rej(new DOMException('Aborted', 'AbortError')); }, { once: true });
+  });
+}


### PR DESCRIPTION
## POC: How-to-Play Tutorial with Animated Demos

Summary

- Add an interactive "How to Play" modal accessible from the POC home screen
- Tutorial has two sections: text steps explaining the rules, and a tabbed examples panel with animated demos
- Three steps: Queue (preview letters arrive left-to-right), Drop (click columns, letters fall and stack), Match (horizontal, vertical, and diagonal word matching)
- Match demo runs a continuous sequence: spells CAT across, DOG down, then builds support letters for a diagonal CAT
- 5-letter preview queue shifts on each drop, matching the in-game preview styling
- All demo visuals (cells, dropping tiles, preview blocks) match the actual game's styles