### PR TITLE
UI/words made

### DIFF
--- a/src/components/Layout/GameLayout.jsx
+++ b/src/components/Layout/GameLayout.jsx
@@ -43,9 +43,19 @@ function GameLayout({
   const inFlightCountRef = useRef(0);
 
   // Lock body scroll while any drop is in flight so position:fixed coords stay valid
+  // Block scroll during drop so position:fixed overlay coords stay valid
   useEffect(() => {
-    document.body.style.overflow = activeDrops.length > 0 ? 'hidden' : '';
-    return () => { document.body.style.overflow = ''; };
+    if (activeDrops.length > 0) {
+      document.body.style.overscrollBehavior = 'none';
+      document.body.style.touchAction = 'none';
+    } else {
+      document.body.style.overscrollBehavior = '';
+      document.body.style.touchAction = '';
+    }
+    return () => {
+      document.body.style.overscrollBehavior = '';
+      document.body.style.touchAction = '';
+    };
   }, [activeDrops.length]);
 
   // Find the destination row for a drop, skipping the `skipFromBottom` lowest empty rows

--- a/src/components/Stats/MadeWords.jsx
+++ b/src/components/Stats/MadeWords.jsx
@@ -9,7 +9,7 @@ function MadeWords({ words = [], dictionary = null, visible = true }) {
           const word = typeof entry === 'string' ? entry : entry.word;
           const definition = dictionary?.get(word);
           return (
-            <div key={index} className="word-item">
+            <div key={word} className="word-item">
               <span className="word-item-word">{word}</span>
               {definition && <span className="word-item-definition">{definition}</span>}
             </div>

--- a/src/poc/App.jsx
+++ b/src/poc/App.jsx
@@ -90,6 +90,7 @@ function App() {
         onColumnClick={handleColumnClick}
         onUndo={undo}
         showPreview={state.status === 'PLAYING' || state.status === 'PROCESSING'}
+        boardVisible={state.status !== 'IDLE'}
         canDrop={state.status === 'PLAYING' || state.status === 'PROCESSING'}
       />
       {gridWrapperRef.current && createPortal(

--- a/src/poc/components/Grid/Board.jsx
+++ b/src/poc/components/Grid/Board.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Cell from '../../../components/Grid/Cell.jsx';
 import { GRID_SIZE, GRID_COLS } from '../../../utils/gameConstants.js';
 
-function Board({ grid = Array(GRID_SIZE).fill(null), onColumnClick, gridRef, highlightColumn = null }) {
+function Board({ grid = Array(GRID_SIZE).fill(null), onColumnClick, gridRef, highlightColumn = null, visible = true }) {
   const handleCellClick = (index) => {
     const column = index % GRID_COLS;
     if (onColumnClick) {
@@ -11,7 +11,7 @@ function Board({ grid = Array(GRID_SIZE).fill(null), onColumnClick, gridRef, hig
   };
 
   return (
-    <div ref={gridRef} className="game-grid">
+    <div ref={gridRef} className={`game-grid${visible ? ' visible' : ''}`}>
       {grid.map((cell, index) => {
         const column = index % GRID_COLS;
         const isHighlighted = highlightColumn !== null && column === highlightColumn;

--- a/src/poc/components/Layout/GameLayout.jsx
+++ b/src/poc/components/Layout/GameLayout.jsx
@@ -131,7 +131,7 @@ function GameLayout({
             <div className="letters-remaining-value">{lettersRemaining}</div>
           </div>
         </div>
-        <Board grid={grid} onColumnClick={handleColumnClick} gridRef={gridRef} highlightColumn={null} />
+        <Board grid={grid} onColumnClick={handleColumnClick} gridRef={gridRef} highlightColumn={null} visible={showPreview} />
       </div>
 
       {/* Made Words Section (Bottom) */}

--- a/src/poc/components/Layout/GameLayout.jsx
+++ b/src/poc/components/Layout/GameLayout.jsx
@@ -34,10 +34,19 @@ function GameLayout({
   // Total in-flight drops — used to index into nextLetters for letter assignment
   const inFlightCountRef = useRef(0);
 
-  // Lock body scroll while any drop is in flight so position:fixed coords stay valid
+  // Block scroll during drop so position:fixed overlay coords stay valid
   useEffect(() => {
-    document.body.style.overflow = activeDrops.length > 0 ? 'hidden' : '';
-    return () => { document.body.style.overflow = ''; };
+    if (activeDrops.length > 0) {
+      document.body.style.overscrollBehavior = 'none';
+      document.body.style.touchAction = 'none';
+    } else {
+      document.body.style.overscrollBehavior = '';
+      document.body.style.touchAction = '';
+    }
+    return () => {
+      document.body.style.overscrollBehavior = '';
+      document.body.style.touchAction = '';
+    };
   }, [activeDrops.length]);
 
   // Find the destination row for a drop, skipping the `skipFromBottom` lowest empty rows

--- a/src/poc/components/Layout/GameLayout.jsx
+++ b/src/poc/components/Layout/GameLayout.jsx
@@ -19,6 +19,7 @@ function GameLayout({
   onColumnClick,
   onUndo,
   showPreview = false,
+  boardVisible = true,
   canDrop = false,
 }) {
   const gridRef = useRef(null);
@@ -131,7 +132,7 @@ function GameLayout({
             <div className="letters-remaining-value">{lettersRemaining}</div>
           </div>
         </div>
-        <Board grid={grid} onColumnClick={handleColumnClick} gridRef={gridRef} highlightColumn={null} visible={showPreview} />
+        <Board grid={grid} onColumnClick={handleColumnClick} gridRef={gridRef} highlightColumn={null} visible={boardVisible} />
       </div>
 
       {/* Made Words Section (Bottom) */}

--- a/src/poc/components/Stats/MadeWords.jsx
+++ b/src/poc/components/Stats/MadeWords.jsx
@@ -8,7 +8,7 @@ function MadeWords({ words = [], dictionary = null }) {
         {words.map((word, index) => {
           const definition = dictionary?.get(word.word);
           return (
-            <div key={index} className="word-item">
+            <div key={word.word} className="word-item">
               <span className="word-item-word">{word.word}</span>
               {definition && <span className="word-item-definition">{definition}</span>}
             </div>

--- a/src/poc/components/Stats/MadeWords.jsx
+++ b/src/poc/components/Stats/MadeWords.jsx
@@ -6,10 +6,10 @@ function MadeWords({ words = [], dictionary = null }) {
       <div className="made-words-title">Words Made</div>
       <div className="words-list">
         {words.map((word, index) => {
-          const definition = dictionary?.get(word);
+          const definition = dictionary?.get(word.word);
           return (
             <div key={index} className="word-item">
-              <span className="word-item-word">{word}</span>
+              <span className="word-item-word">{word.word}</span>
               {definition && <span className="word-item-definition">{definition}</span>}
             </div>
           );

--- a/src/poc/styles/grid.css
+++ b/src/poc/styles/grid.css
@@ -7,14 +7,17 @@
 /* Grid Wrapper Container */
 .game-grid-wrapper {
     flex: 3;
+    min-height: 0;
     background: var(--color-bg-card);
     border-radius: var(--size-border-radius-card);
     padding: var(--size-padding-card);
     box-shadow: var(--shadow-card);
     display: flex;
     flex-direction: column;
+    align-items: center;
     gap: 10px;
     position: relative;
+    overflow: hidden;
 }
 
 /* Preview Row (contains preview tiles and letters remaining) */
@@ -22,6 +25,7 @@
     display: flex;
     align-items: center;
     gap: 10px;
+    width: 100%;
 }
 
 .preview-row.tutorial-clickable {
@@ -123,13 +127,20 @@
     gap: 1px;
     border-radius: var(--size-border-radius-grid);
     position: relative;
-    flex: 1;
+    aspect-ratio: 7 / 6;
     width: 100%;
-    height: 100%;
-    max-height: 70dvh;
-    max-width: 900px;
-    margin: 0 auto;
+    max-height: 100%;
+    opacity: 0;
+    transform: scale(0.95);
+    transition: opacity var(--transition-standard), transform var(--transition-standard);
+    pointer-events: none;
     touch-action: manipulation;
+}
+
+.game-grid.visible {
+    opacity: 1;
+    transform: scale(1);
+    pointer-events: auto;
 }
 
 /* Individual Grid Square - Extends .block-base */

--- a/src/poc/styles/grid.css
+++ b/src/poc/styles/grid.css
@@ -129,6 +129,7 @@
     position: relative;
     aspect-ratio: 7 / 6;
     width: 100%;
+    max-width: 100%;
     max-height: 100%;
     opacity: 0;
     transform: scale(0.95);

--- a/src/poc/styles/grid.css
+++ b/src/poc/styles/grid.css
@@ -43,7 +43,7 @@
 
 /* Next Letters Preview (Queue of upcoming letters) */
 .next-letters-preview {
-    display: none;
+    display: flex;
     justify-content: flex-start;
     gap: 5px;
     opacity: 0;
@@ -52,7 +52,6 @@
 }
 
 .next-letters-preview.visible {
-    display: flex;
     opacity: 1;
     visibility: visible;
 }

--- a/src/poc/styles/made-words.css
+++ b/src/poc/styles/made-words.css
@@ -27,6 +27,13 @@
     display: flex;
     flex-direction: column;
     gap: 10px;
+    max-height: 160px;
+    overflow-y: auto;
+    scrollbar-width: none;
+}
+
+.words-list::-webkit-scrollbar {
+    display: none;
 }
 
 /* Individual Word Item */

--- a/src/replay/ReplayApp.jsx
+++ b/src/replay/ReplayApp.jsx
@@ -167,7 +167,9 @@ export function ReplayApp() {
           <button onClick={advance} disabled={!canGoFwd}>→</button>
         </div>
 
-        <Board grid={grid} onColumnClick={null} visible />
+        <div className="replay-grid-wrapper">
+          <Board grid={grid} onColumnClick={null} visible />
+        </div>
 
         {turn && <TurnDetail turn={turn} stepIdx={stepIdx} score={score} />}
       </main>

--- a/src/replay/replay.css
+++ b/src/replay/replay.css
@@ -139,6 +139,20 @@ body {
 
 /* ─── Responsive ─────────────────────────────────────────────────────────── */
 
+/* ─── Grid wrapper ──────────────────────────────────────────────────────── */
+
+.replay-grid-wrapper {
+  width: 100%;
+  max-height: 60vh;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  overflow: hidden;
+}
+
+/* ─── Responsive ─────────────────────────────────────────────────────────── */
+
 @media (max-width: 500px) {
   .replay-sidebar { width: 100px; }
   .turn-detail { max-width: 100%; }

--- a/src/replay/replay.css
+++ b/src/replay/replay.css
@@ -143,7 +143,7 @@ body {
 
 .replay-grid-wrapper {
   width: 100%;
-  max-height: 60vh;
+  max-width: 500px;
   min-height: 0;
   display: flex;
   flex-direction: column;

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -121,7 +121,7 @@ body {
     display: flex;
     flex-direction: column;
     gap: var(--size-gap-large);
-    max-width: 1400px;
+    max-width: 600px;
     margin: 0 auto;
 }
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -115,6 +115,7 @@ body {
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     padding: 20px;
     min-height: 100dvh;
+    scrollbar-gutter: stable;
 }
 
 .main-container {

--- a/src/styles/grid.css
+++ b/src/styles/grid.css
@@ -129,6 +129,7 @@
     position: relative;
     aspect-ratio: 7 / 6;
     width: 100%;
+    max-width: 100%;
     max-height: 100%;
     opacity: 0;
     transform: scale(0.95);

--- a/src/styles/grid.css
+++ b/src/styles/grid.css
@@ -7,14 +7,17 @@
 /* Grid Wrapper Container */
 .game-grid-wrapper {
     flex: 3;
+    min-height: 0;
     background: var(--color-bg-card);
     border-radius: var(--size-border-radius-card);
     padding: var(--size-padding-card);
     box-shadow: var(--shadow-card);
     display: flex;
     flex-direction: column;
+    align-items: center;
     gap: 10px;
     position: relative;
+    overflow: hidden;
 }
 
 /* Preview Row (contains preview tiles and letters remaining) */
@@ -22,6 +25,7 @@
     display: flex;
     align-items: center;
     gap: 10px;
+    width: 100%;
 }
 
 .preview-row.tutorial-clickable {
@@ -123,12 +127,9 @@
     gap: 1px;
     border-radius: var(--size-border-radius-grid);
     position: relative;
-    flex: 1;
+    aspect-ratio: 7 / 6;
     width: 100%;
-    height: 100%;
-    max-height: 70dvh;
-    max-width: 900px;
-    margin: 0 auto;
+    max-height: 100%;
     opacity: 0;
     transform: scale(0.95);
     transition: opacity var(--transition-standard), transform var(--transition-standard);


### PR DESCRIPTION
**Fix grid sizing, layout shift, and MadeWords rendering across classic, poc, and replay**

Three areas of work:

**Grid sizing & aspect ratio**
The game grid was using `flex:1` + `height:100%` which made its size dependent on sibling height. Replaced with `aspect-ratio:7/6` so it always holds its shape. The classic and poc wrappers got `min-height:0` + `overflow:hidden` to properly contain the grid in a flex column. Main container capped at 600px (was 1400px). The replay viewer got a dedicated `replay-grid-wrapper` to cap width instead of height.

**Board visibility in poc**
The poc `Board` wasn't receiving a `visible` prop, so the grid never applied the `.visible` class and the fade-in animation didn't work. Wired `boardVisible` from `App` through `GameLayout` to `Board`.

**Layout shift (CLS) prevention**
- `scrollbar-gutter:stable` on body permanently reserves scrollbar width
- Drop animation scroll lock replaced: `overflow:hidden` (which hides the scrollbar gutter) → `overscrollBehavior`+`touchAction` (which block scroll drift without touching gutter)
- Preview row changed from `display:none` to `display:flex`+`visibility:hidden` so it always occupies its row height
- Made-words list capped with `max-height`+`overflow-y:auto` to grow internally
- `MadeWords` keys changed from `index` to `word` for stable React identity

**MadeWords data fix (poc)**
Words in the poc were objects `{word, ...}` but the component was treating them as strings. Fixed dictionary lookup and display to access `.word`.
