### PR TITLE
feat: redesign How to Play modal as panel-per-step carousel

### DIFF
--- a/src/poc/AnimatedDemo.jsx
+++ b/src/poc/AnimatedDemo.jsx
@@ -22,14 +22,16 @@ const ordinalOf = n => ['1st', '2nd', '3rd', '4th', '5th'][n - 1];
 
 function useDemo(demoType) {
   const [vis, setVis] = useState({
-    grid:        emptyGrid(),
-    queue:       ['C', 'A', 'B', 'C', 'A'],
-    dropping:    null,
-    cursorCol:   null,
-    cursorClick: false,
-    highlight:   null,
-    showOrder:   false,
-    caption:     '',
+    grid:          emptyGrid(),
+    queue:         ['C', 'A', 'B', 'C', 'A'],
+    dropping:      null,
+    cursorCol:     null,
+    cursorClick:   false,
+    highlight:     null,
+    showOrder:     false,
+    caption:       '',
+    cycleKey:      0,
+    cycleDuration: 0,
   });
 
   const ref = useRef(vis);
@@ -118,6 +120,8 @@ function useDemo(demoType) {
     const demos = {
       'click-plan': async () => {
         while (!signal.aborted) {
+          const cycleStart = Date.now();
+          set(s => ({ ...s, cycleKey: s.cycleKey + 1 }));
           const q = ['C', 'A', 'T', 'S', 'B'].map((l, i) => ({ letter: l, order: i + 1 }));
           set(s => ({ ...s, grid: emptyGrid(), highlight: null, showOrder: true, queue: q, caption: 'Letters drop in order: 1st, 2nd, 3rd...' }));
           await wait(1800);
@@ -131,11 +135,14 @@ function useDemo(demoType) {
           await wait(500);
           set(s => ({ ...s, caption: 'Plan ahead using the queue!' }));
           await wait(1500);
+          set(s => ({ ...s, cycleDuration: Date.now() - cycleStart }));
         }
       },
 
       win: async () => {
         while (!signal.aborted) {
+          const cycleStart = Date.now();
+          set(s => ({ ...s, cycleKey: s.cycleKey + 1 }));
           // Pre-placed tiles (white): C(3,0), A(3,1), O(2,1)
           const startGrid = emptyGrid();
           startGrid[3 * COLS + 0] = { letter: 'C', preplaced: true };
@@ -157,11 +164,14 @@ function useDemo(demoType) {
 
           set(s => ({ ...s, caption: 'Board cleared — you win!' }));
           await wait(2000);
+          set(s => ({ ...s, cycleDuration: Date.now() - cycleStart }));
         }
       },
 
       match: async () => {
         while (!signal.aborted) {
+          const cycleStart = Date.now();
+          set(s => ({ ...s, cycleKey: s.cycleKey + 1 }));
           const fullQueue = ['C', 'A', 'T', 'G', 'O', 'D', 'X', 'Y', 'Z', 'T', 'C', 'A'];
           set(s => ({ ...s, grid: emptyGrid(), highlight: null, queue: fullQueue, caption: 'Spell words left to right' }));
           await wait(800);
@@ -193,6 +203,7 @@ function useDemo(demoType) {
           await dropLetter(1, 'A completes the diagonal!'); // A → (2,1)
           await highlightWord([1 * COLS + 0, 2 * COLS + 1, 3 * COLS + 2], '"CAT" diagonal — nice!');
           await wait(1000);
+          set(s => ({ ...s, cycleDuration: Date.now() - cycleStart }));
         }
       },
     };
@@ -205,10 +216,11 @@ function useDemo(demoType) {
 }
 
 export default function AnimatedDemo({ demoType = 'drop' } = {}) {
-  const { grid, queue, dropping, cursorCol, cursorClick, highlight, showOrder, caption } = useDemo(demoType);
+  const { grid, queue, dropping, cursorCol, cursorClick, highlight, showOrder, caption, cycleKey, cycleDuration } = useDemo(demoType);
 
   return (
     <div style={d.wrapper}>
+      <style>{`@keyframes htp-progress { from { width: 0% } to { width: 100% } }`}</style>
       {/* 5-letter preview queue */}
       <div style={d.previewRow}>
         {Array(PREVIEW_SIZE).fill(null).map((_, i) => {
@@ -308,6 +320,13 @@ export default function AnimatedDemo({ demoType = 'drop' } = {}) {
       </div>
 
       <p style={d.caption}>{caption || '\u00a0'}</p>
+
+      <div style={d.progressTrack}>
+        <div
+          key={cycleKey}
+          style={{ ...d.progressFill, animationDuration: `${cycleDuration / 1000}s` }}
+        />
+      </div>
     </div>
   );
 }
@@ -392,5 +411,16 @@ const d = {
   caption: {
     fontSize: 13, color: '#555', textAlign: 'center',
     minHeight: 36, maxWidth: 220, lineHeight: 1.4, margin: 0,
+  },
+  progressTrack: {
+    width: GRID_W, height: 3, borderRadius: 2,
+    background: '#e0e0e0', overflow: 'hidden',
+  },
+  progressFill: {
+    height: '100%', width: 0, borderRadius: 2,
+    background: '#1976D2',
+    animationName: 'htp-progress',
+    animationTimingFunction: 'linear',
+    animationFillMode: 'forwards',
   },
 };

--- a/src/poc/AnimatedDemo.jsx
+++ b/src/poc/AnimatedDemo.jsx
@@ -316,8 +316,8 @@ const d = {
   wrapper:      { display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8 },
   previewRow:   { display: 'flex', alignItems: 'flex-end', gap: 5 },
   previewCol:   { display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 3 },
-  orderLabel:   { fontSize: 14, fontWeight: 700, color: '#333', lineHeight: 1 },
-  orderLabelPlaceholder: { height: 14 },
+  orderLabel:   { display: 'block', height: 14, fontSize: 14, fontWeight: 700, color: '#333', lineHeight: 1 },
+  orderLabelPlaceholder: { display: 'block', height: 14 },
   previewCell:  {
     width: PCELL, height: PCELL, borderRadius: 7,
     background: '#888', border: '2px solid #333',

--- a/src/poc/HowToPlayModal.jsx
+++ b/src/poc/HowToPlayModal.jsx
@@ -1,10 +1,12 @@
 import { useState } from 'react';
 import AnimatedDemo from './AnimatedDemo.jsx';
-import { STEPS, DEMOS } from './constants.js';
+import { PANELS } from './constants.js';
 
 export default function HowToPlayModal({ onClose = () => {} } = {}) {
-  const [exampleIdx, setExampleIdx] = useState(0);
-  const current = DEMOS[exampleIdx];
+  const [panelIdx, setPanelIdx] = useState(0);
+  const panel = PANELS[panelIdx];
+  const isFirst = panelIdx === 0;
+  const isLast  = panelIdx === PANELS.length - 1;
 
   return (
     <div style={m.backdrop} onClick={onClose}>
@@ -12,9 +14,9 @@ export default function HowToPlayModal({ onClose = () => {} } = {}) {
 
         <h2 style={m.title}>How to Play</h2>
 
-        {/* Steps (text only) */}
-        <div style={m.steps}>
-          {STEPS.map(step => (
+        {/* Panel content */}
+        <div style={m.panelContent}>
+          {panel.steps.map(step => (
             <div key={step.number} style={m.step}>
               <div style={m.stepHeader}>
                 <span style={m.stepNumber}>{step.number}</span>
@@ -23,29 +25,45 @@ export default function HowToPlayModal({ onClose = () => {} } = {}) {
               <p style={m.stepDesc}>{step.description}</p>
             </div>
           ))}
+
+          <AnimatedDemo key={panelIdx} demoType={panel.demoType} />
         </div>
 
-        {/* Divider */}
-        <hr style={m.divider} />
+        {/* Nav row */}
+        <div style={m.navRow}>
+          <button
+            style={{ ...m.arrowBtn, opacity: isFirst ? 0.3 : 1 }}
+            onClick={() => setPanelIdx(i => i - 1)}
+            disabled={isFirst}
+            aria-label="Previous"
+          >
+            ‹
+          </button>
 
-        {/* Examples panel */}
-        <div style={m.exampleSection}>
-          <div style={m.exampleTabs}>
-            {DEMOS.map((demo, i) => (
+          <div style={m.dots}>
+            {PANELS.map((_, i) => (
               <button
                 key={i}
-                style={{ ...m.tab, ...(i === exampleIdx ? m.tabActive : {}) }}
-                onClick={() => setExampleIdx(i)}
-              >
-                {demo.title}
-              </button>
+                style={{ ...m.dot, ...(i === panelIdx ? m.dotActive : {}) }}
+                onClick={() => setPanelIdx(i)}
+                aria-label={`Panel ${i + 1}`}
+              />
             ))}
           </div>
 
-          <AnimatedDemo key={exampleIdx} demoType={current.demoType} />
+          <button
+            style={{ ...m.arrowBtn, opacity: isLast ? 0.3 : 1 }}
+            onClick={() => setPanelIdx(i => i + 1)}
+            disabled={isLast}
+            aria-label="Next"
+          >
+            ›
+          </button>
         </div>
 
-        <button style={m.gotItBtn} onClick={onClose}>Got it</button>
+        {isLast && (
+          <button style={m.gotItBtn} onClick={onClose}>Got it</button>
+        )}
 
       </div>
     </div>
@@ -65,11 +83,12 @@ const m = {
     overflowY: 'auto',
   },
   title: { fontSize: 20, fontWeight: 700, color: '#333', margin: 0 },
-  steps: {
-    width: '100%', display: 'flex', flexDirection: 'column', gap: 16,
+  panelContent: {
+    width: '100%', display: 'flex', flexDirection: 'column',
+    alignItems: 'center', gap: 12,
   },
   step: {
-    display: 'flex', flexDirection: 'column', gap: 4,
+    width: '100%', display: 'flex', flexDirection: 'column', gap: 4,
   },
   stepHeader: {
     display: 'flex', alignItems: 'center', gap: 8,
@@ -89,27 +108,26 @@ const m = {
     fontSize: 13, color: '#555', lineHeight: 1.4,
     margin: '0 0 0 30px',
   },
-  divider: {
-    width: '100%', border: 'none',
-    borderTop: '1px solid #e0e0e0', margin: '4px 0',
+  navRow: {
+    width: '100%', display: 'flex', alignItems: 'center',
+    justifyContent: 'space-between', marginTop: 4,
   },
-  exampleSection: {
-    width: '100%', display: 'flex', flexDirection: 'column',
-    alignItems: 'center', gap: 12,
+  arrowBtn: {
+    background: 'none', border: 'none', fontSize: 28,
+    color: '#1976D2', cursor: 'pointer', padding: '4px 10px',
+    lineHeight: 1, borderRadius: 6,
+    transition: 'opacity 0.15s', userSelect: 'none',
   },
-  exampleTabs: {
-    display: 'flex', gap: 0, borderRadius: 8, overflow: 'hidden',
-    border: '2px solid #1976D2',
+  dots: {
+    display: 'flex', gap: 8, alignItems: 'center',
   },
-  tab: {
-    padding: '6px 20px', fontSize: 12, fontWeight: 600,
-    textTransform: 'uppercase', letterSpacing: '0.04em',
-    border: 'none', cursor: 'pointer',
-    background: '#fff', color: '#1976D2',
-    transition: 'background 0.15s, color 0.15s',
+  dot: {
+    width: 8, height: 8, borderRadius: '50%',
+    background: '#ccc', border: 'none', padding: 0,
+    cursor: 'pointer', transition: 'background 0.2s, transform 0.2s',
   },
-  tabActive: {
-    background: '#1976D2', color: '#fff',
+  dotActive: {
+    background: '#1976D2', transform: 'scale(1.25)',
   },
   gotItBtn: {
     width: '100%', padding: '10px 0', borderRadius: 8,

--- a/src/poc/HowToPlayModal.jsx
+++ b/src/poc/HowToPlayModal.jsx
@@ -16,15 +16,17 @@ export default function HowToPlayModal({ onClose = () => {} } = {}) {
 
         {/* Panel content */}
         <div style={m.panelContent}>
-          {panel.steps.map(step => (
-            <div key={step.number} style={m.step}>
-              <div style={m.stepHeader}>
-                <span style={m.stepNumber}>{step.number}</span>
-                <span style={m.stepTitle}>{step.title}</span>
+          <div style={m.stepsArea}>
+            {panel.steps.map(step => (
+              <div key={step.number} style={m.step}>
+                <div style={m.stepHeader}>
+                  <span style={m.stepNumber}>{step.number}</span>
+                  <span style={m.stepTitle}>{step.title}</span>
+                </div>
+                <p style={m.stepDesc}>{step.description}</p>
               </div>
-              <p style={m.stepDesc}>{step.description}</p>
-            </div>
-          ))}
+            ))}
+          </div>
 
           <AnimatedDemo key={panelIdx} demoType={panel.demoType} />
         </div>
@@ -61,9 +63,12 @@ export default function HowToPlayModal({ onClose = () => {} } = {}) {
           </button>
         </div>
 
-        {isLast && (
-          <button style={m.gotItBtn} onClick={onClose}>Got it</button>
-        )}
+        <button
+          style={{ ...m.gotItBtn, visibility: isLast ? 'visible' : 'hidden' }}
+          onClick={onClose}
+        >
+          Got it
+        </button>
 
       </div>
     </div>
@@ -86,6 +91,10 @@ const m = {
   panelContent: {
     width: '100%', display: 'flex', flexDirection: 'column',
     alignItems: 'center', gap: 12,
+  },
+  stepsArea: {
+    width: '100%', minHeight: 104,
+    display: 'flex', flexDirection: 'column', gap: 16,
   },
   step: {
     width: '100%', display: 'flex', flexDirection: 'column', gap: 4,

--- a/src/poc/constants.js
+++ b/src/poc/constants.js
@@ -17,3 +17,25 @@ export const DEMOS = [
   { title: 'MAKE',         demoType: 'match' },
   { title: 'WIN',          demoType: 'win' },
 ];
+
+export const PANELS = [
+  {
+    steps: [
+      { number: 1, title: 'CLICK', description: 'a column to drop the next letter onto the board. It falls to the lowest empty tile.' },
+      { number: 2, title: 'PLAN',  description: 'ahead using the letter queue. Letters arrive in order from left to right.' },
+    ],
+    demoType: 'click-plan',
+  },
+  {
+    steps: [
+      { number: 3, title: 'MAKE', description: 'words horizontally, vertically, or diagonally. Three-letter minimum.' },
+    ],
+    demoType: 'match',
+  },
+  {
+    steps: [
+      { number: 4, title: 'WIN', description: 'by clearing every tile. Words only count if they include a tile you placed.' },
+    ],
+    demoType: 'win',
+  },
+];


### PR DESCRIPTION

- Each step now has its own panel with text and animated demo together.
Steps 1 (CLICK) and 2 (PLAN) are merged into a single panel since
they share the click-plan demo. Navigation uses prev/next arrows and
clickable dots. "Got it" only appears on the last panel.
- Add progress bar
