### PR TITLE
feat: Railway deployment, leaderboard, and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm run dev          # Vite dev server at http://localhost:5173 (hot reload)
+npm run build        # Production build → dist/
+npm start            # Express server at http://localhost:3000 (serves dist/)
+npm test             # Jest unit tests
+npm run test:watch   # Jest in watch mode
+npm test -- --testPathPattern=gameReducer  # Run single test file
+npm run migrate      # Create leaderboard table in PostgreSQL
+```
+
+## Architecture
+
+The app is a React 18 + Vite SPA deployed on Railway with an Express.js backend (`server.js`) that serves the built `dist/` and provides a leaderboard API (`POST/GET /api/scores`) backed by PostgreSQL.
+
+**Vite multi-entry build**: Three entry points are bundled — `index.html` (main game), `poc.html` (prototype/how-to-play), and `game_replay.html` (replay viewer). Each has its own `src/.../main.jsx`.
+
+### Game state: Context + Reducer
+
+All runtime game state lives in `src/context/GameReducer.js` (`initialState`) and is distributed via `src/context/GameContext.jsx`. The state shape is:
+- `grid`: flat 42-element array (6 rows × 7 cols), each cell is `null` or a tile object `{ char, id, type, isMatched, isPending, pendingDirections, ... }`
+- `status`: `'IDLE' | 'PLAYING' | 'GAME_OVER' | 'PROCESSING'`
+- `gameMode`: `'classic' | 'clear'`
+
+### Core game loop (`src/hooks/useGameLogic.js`)
+
+This is the most complex file. It drives the entire gameplay cycle:
+1. Player drops a letter → `DROP_LETTER` action
+2. Hook scans for words using `findWords()` from `wordUtils.js` (horizontal + vertical)
+3. Detected words enter a **grace period** (1000ms) with a countdown animation — tracked in `pendingRef` (a `Map<wordKey, entry>`)
+4. On expiry, intersecting words expire together (transitive BFS), triggering `SET_MATCHED_INDICES` → `REMOVE_WORDS` → `APPLY_GRAVITY`
+5. After gravity, the loop re-scans for combo chains
+
+### Session persistence (`src/services/gameSession.js`, `src/hooks/useGameSession.js`)
+
+Sessions are **event-sourced** (schema v3): every `DROP_LETTER`, `WORDS_CLEARED`, and `GRAVITY` event is appended and immediately written to `localStorage`. On resume, state is derived from the stored checkpoint (not full event replay). The session model is pure (no React, no I/O) — all side effects live in the hook.
+
+### Game modes
+
+- **Classic**: score by word length; `calculateWordScore()` in `scoringUtils.js`
+- **Clear**: board starts 20% pre-filled with blocks; scoring is `lettersRemaining` at word-clear time; win condition is clearing all initial blocks
+
+### URL debug flags
+
+Append to any URL during development:
+- `?debug=true` — debug overlay
+- `?skipAnimations=true` — skip Framer Motion animations
+- `?debugGrid=true` — grid pattern overlay
+- `?betaClearModeEmptyBoard=true` — stricter clear-mode win (fully empty board)
+
+## Database
+
+The app requires `DATABASE_URL` in `.env`. The `.env` file has two URLs (`LOCAL_DATABASE_URL`, `RAILWAY_DATABASE_URL`) — toggle which one `DATABASE_URL` points to.
+
+Run `npm run migrate` once to create the `leaderboard` table before starting the server locally.
+
+Local PostgreSQL (Homebrew): `brew services start postgresql@16`, connect at `postgresql://localhost:5432/noodel_dev`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,25 @@
-# Use the official Node.js runtime as base image
-FROM node:18-alpine
+FROM node:18-alpine AS builder
 
-# Set the working directory in the container
 WORKDIR /app
 
-# Copy package.json and package-lock.json (if available)
 COPY package*.json ./
+RUN npm ci
 
-# Install dependencies
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
 RUN npm ci --only=production
 
-# Copy the rest of the application code
-COPY . .
+COPY --from=builder /app/dist ./dist
+COPY server.js ./
+COPY scripts ./scripts
 
-# Expose the port the app runs on
 EXPOSE 3000
 
-# Define the command to run the application
 CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -120,6 +120,53 @@ test('should handle letter placement', () => {
 });
 ```
 
+### Local Database
+
+The app uses PostgreSQL. Your `.env` file has two database URLs — toggle `DATABASE_URL` between them to switch between local and Railway.
+
+**Verify local PostgreSQL is running:**
+```bash
+brew services list | grep postgresql
+# Should show: postgresql@16   started
+```
+
+**Connect and inspect the database:**
+```bash
+psql postgresql://localhost:5432/noodel_dev
+```
+
+Once inside `psql`, useful commands:
+```sql
+-- List all tables
+\dt
+
+-- Check database connection info
+\conninfo
+
+-- Exit
+\q
+```
+
+**Quick one-liner health check (no psql prompt):**
+```bash
+psql postgresql://localhost:5432/noodel_dev -c "SELECT current_database(), now();"
+```
+
+**Stop / start the local database:**
+```bash
+brew services stop postgresql@16
+brew services start postgresql@16
+```
+
+**Switch to Railway database** (edit `.env`):
+```env
+# Local development
+DATABASE_URL=${LOCAL_DATABASE_URL}
+
+# Remote Railway (production/staging)
+DATABASE_URL=${RAILWAY_DATABASE_URL}
+```
+
 ### Debug Features
 
 Add these URL parameters for debugging:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "dotenv": "^17.4.2",
         "express": "^4.18.2",
         "express-static-gzip": "^2.1.7",
         "framer-motion": "^10.16.16",
+        "pg": "^8.20.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -2773,6 +2775,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -5051,6 +5065,95 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5121,6 +5224,45 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/pretty-format": {
@@ -5688,6 +5830,15 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -6280,6 +6431,15 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -11,23 +11,26 @@
     "preview": "vite preview",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --watch",
-    "test:coverage": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage"
+    "test:coverage": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage",
+    "migrate": "node scripts/migrate.js"
   },
   "engines": {
     "node": ">=18.0.0",
     "npm": ">=8.0.0"
   },
   "dependencies": {
+    "dotenv": "^17.4.2",
     "express": "^4.18.2",
     "express-static-gzip": "^2.1.7",
+    "framer-motion": "^10.16.16",
+    "pg": "^8.20.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "framer-motion": "^10.16.16"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "@vitejs/plugin-react": "^4.2.1",
     "vite": "^5.0.8"
   },
   "keywords": [

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import pg from 'pg';
+
+const { Pool } = pg;
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+const sql = `
+  CREATE TABLE IF NOT EXISTS leaderboard (
+    id         SERIAL PRIMARY KEY,
+    username   TEXT    NOT NULL DEFAULT 'anonymous',
+    score      INTEGER NOT NULL,
+    game_mode  TEXT    NOT NULL DEFAULT 'classic',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  );
+`;
+
+try {
+  await pool.query(sql);
+  console.log('✅ leaderboard table ready');
+} finally {
+  await pool.end();
+}

--- a/server.js
+++ b/server.js
@@ -1,18 +1,26 @@
 
+import 'dotenv/config';
 import express from 'express';
 import expressStaticGzip from 'express-static-gzip';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
+import pg from 'pg';
+
+const { Pool } = pg;
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+const DIST = path.join(__dirname, 'dist');
 
-// Enable gzip compression for static files
-app.use('/', expressStaticGzip(path.join(__dirname), {
+app.use(express.json());
+
+// Serve compressed assets from dist/
+app.use('/', expressStaticGzip(DIST, {
   enableBrotli: true,
   customCompressions: [{
     encodingName: 'deflate',
@@ -21,23 +29,32 @@ app.use('/', expressStaticGzip(path.join(__dirname), {
   orderPreference: ['br', 'gzip']
 }));
 
-// Set proper MIME types for JavaScript modules
-app.use((req, res, next) => {
-  if (req.url.endsWith('.js')) {
-    res.type('application/javascript');
-  }
-  next();
-});
-
-// Serve static files
-app.use(express.static(__dirname, {
-  maxAge: '1d', // Cache static assets for 1 day
+app.use(express.static(DIST, {
+  maxAge: '1d',
   etag: true
 }));
 
-// Handle SPA routing - serve index.html for unknown routes
+// Leaderboard API
+app.post('/api/scores', async (req, res) => {
+  const { score, gameMode } = req.body;
+  if (typeof score !== 'number') return res.status(400).json({ error: 'score required' });
+  const result = await pool.query(
+    'INSERT INTO leaderboard (score, game_mode) VALUES ($1, $2) RETURNING *',
+    [score, gameMode || 'classic']
+  );
+  res.status(201).json(result.rows[0]);
+});
+
+app.get('/api/scores', async (req, res) => {
+  const result = await pool.query(
+    'SELECT * FROM leaderboard ORDER BY score DESC LIMIT 20'
+  );
+  res.json(result.rows);
+});
+
+// Handle SPA routing - serve dist/index.html for all other routes
 app.get('*', (req, res) => {
-  res.sendFile(path.join(__dirname, 'index.html'));
+  res.sendFile(path.join(DIST, 'index.html'));
 });
 
 app.listen(PORT, '0.0.0.0', () => {

--- a/src/context/GameContext.jsx
+++ b/src/context/GameContext.jsx
@@ -82,10 +82,15 @@ export function GameProvider({ children }) {
     dispatch(action);
   }, [dispatch, gameSession]);
 
-  // Mark session complete when game ends.
+  // Mark session complete and save score when game ends.
   useEffect(() => {
     if (state.status === 'GAME_OVER') {
       gameSession.onGameOver(state);
+      fetch('/api/scores', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ score: state.score, gameMode: state.gameMode }),
+      }).catch(() => {}); // fire-and-forget; don't break the game on DB errors
     }
   }, [state.status]);
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: '/noodel_new/',
+  base: process.env.RAILWAY_ENVIRONMENT ? '/noodel_new/' : '/',
   plugins: [
     react({
       jsxRuntime: 'automatic',


### PR DESCRIPTION
## Summary

- **Multi-stage Dockerfile**: Separates build and runtime stages for a leaner production image
- **Leaderboard with PostgreSQL**: `POST/GET /api/scores` backed by a `leaderboard` table; `npm run migrate` creates the table
- **CLAUDE.md**: Initial architecture doc covering commands, file layout, game state shape, and core loop
- **Local DB docs**: Instructions for toggling `DATABASE_URL` between local and Railway Postgres

## Test plan

- [ ] `npm run build` produces a clean dist
- [ ] `npm run migrate` creates the leaderboard table against a local Postgres instance
- [ ] `npm start` serves the built app and leaderboard API at port 3000
- [ ] `POST /api/scores` inserts a row; `GET /api/scores` returns the leaderboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)