### PR TITLE
docs+fix: game flow audit, replay system fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,45 @@ Append to any URL during development:
 - `?skipAnimations=true` — skip Framer Motion animations
 - `?debugGrid=true` — grid pattern overlay
 
+## Design Decisions
+
+### Game loop timing constants (`src/hooks/useGameLogic.js`)
+
+| Constant | Value | Purpose |
+|---|---|---|
+| `GRACE_PERIOD_MS` | 1000ms | How long a detected word shows its countdown before clearing |
+| `SHAKE_DURATION_MS` | 400ms | Shake animation duration after `SET_MATCHED_INDICES` fires |
+| `GRAVITY_DELAY_MS` | 150ms | Pause after tiles clear before gravity drops remaining tiles |
+
+### `PROCESSING` status
+
+`SET_MATCHED_INDICES` sets `status: 'PROCESSING'` while tiles are shaking. The word detection effect in `useGameLogic.js` checks `status !== 'PLAYING'` and skips, preventing double-detection of shaking tiles. However, the UI still allows player drops during `PROCESSING` — this is intentional so fast players aren't blocked during animations.
+
+### Grace period word classification (`src/utils/gracePeriodUtils.js`)
+
+Every grid change re-runs word detection. Each found word is classified against the current pending set:
+- **`skip`**: same word already pending, or a same-direction partial overlap (only one timer runs per linear tile run to avoid timer proliferation)
+- **`extend`**: new word is a strict superset of an existing same-direction pending word — replaces it with a fresh timer
+- **`add`**: genuinely new word; also resets timers for all cross-direction words sharing any cell
+
+### Transitive BFS expiration (`expireWord` in `useGameLogic.js`)
+
+When a word's grace period expires, a BFS finds all pending words that intersect it (transitively). If A∩B and B∩C, then A, B, and C all expire together even if A∩C=∅. This prevents partial-word scenarios where two halves of a cross would disappear at different times.
+
+### Gravity concurrency guards
+
+Two refs prevent double-gravity when multiple words expire in the same tick:
+- **`pendingRemovesRef`**: counts in-flight `REMOVE_WORDS` dispatches; gravity only schedules when this reaches 0
+- **`gravityScheduledRef`**: set true the moment gravity is scheduled, blocks any subsequent expiry callbacks from scheduling a second gravity
+
+### Session event sourcing (`src/services/gameSession.js`)
+
+Events (DROP_LETTER, WORDS_CLEARED, GRAVITY) are recorded at the `wrappedDispatch` intercept in `GameContext.jsx` and written to `localStorage` immediately — every event is crash-safe. A checkpoint (derivable from events) is only stored at game-over as an optimization for fast resume. Mid-game resume falls back to full `replayAll()` from the event log. The session model itself is pure (no React, no I/O); all side effects live in `useGameSession.js`.
+
+### Clear mode scoring design
+
+In `REMOVE_WORDS`, Clear mode uses assignment (`totalScore = state.lettersRemaining`) not accumulation (`totalScore +=`). The final `score:` field is also set rather than added to. This means: your score equals the letters remaining at the time of your most recent clear, regardless of how many words cleared simultaneously. This is intentional — it creates a "beat the clock" feel where every drop costs potential score.
+
 ## Database
 
 The app requires `DATABASE_URL` in `.env`. The `.env` file has two URLs (`LOCAL_DATABASE_URL`, `RAILWAY_DATABASE_URL`) — toggle which one `DATABASE_URL` points to.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Sessions are **event-sourced** (schema v3): every `DROP_LETTER`, `WORDS_CLEARED`
 ### Game modes
 
 - **Classic**: score by word length; `calculateWordScore()` in `scoringUtils.js`
-- **Clear**: board starts 20% pre-filled with blocks; scoring is `lettersRemaining` at word-clear time; win condition is clearing all initial blocks
+- **Clear**: board starts 20% pre-filled with blocks; score is set (not accumulated) to `lettersRemaining` at the time of each clear — the score reflects the most recent clear only; win condition is a fully empty board (all cells null, including player-placed tiles)
 
 ### URL debug flags
 
@@ -51,7 +51,6 @@ Append to any URL during development:
 - `?debug=true` — debug overlay
 - `?skipAnimations=true` — skip Framer Motion animations
 - `?debugGrid=true` — grid pattern overlay
-- `?betaClearModeEmptyBoard=true` — stricter clear-mode win (fully empty board)
 
 ## Database
 

--- a/src/context/GameReducer.js
+++ b/src/context/GameReducer.js
@@ -142,6 +142,9 @@ export function gameReducer(state, action) {
       wordsToRemove.forEach(({ word, indices }) => {
         let wordScore;
         if (state.gameMode === 'clear') {
+          // Intentional assignment (not +=): score = lettersRemaining at time of this clear.
+          // Multiple simultaneous clears still yield a single snapshot value. The final
+          // `score:` below also sets (not adds) so the score reflects the latest clear only.
           totalScore = state.lettersRemaining;
           wordScore = state.lettersRemaining;
         } else {

--- a/src/hooks/useGameLogic.js
+++ b/src/hooks/useGameLogic.js
@@ -217,6 +217,8 @@ export function useGameLogic() {
   useEffect(() => {
     if (state.gameMode !== 'clear' || state.status !== 'PLAYING') return;
 
+    // Win requires the entire board to be empty (not just the initial block cells).
+    // Player-placed tiles must also be cleared for victory to trigger.
     const gridEmpty = state.grid.every(cell => !cell);
 
     if (gridEmpty && state.initialBlocks.length > 0) {

--- a/src/hooks/useGameSession.js
+++ b/src/hooks/useGameSession.js
@@ -12,7 +12,7 @@ import {
   completeSession,
   buildLoadPayload,
 } from '../services/gameSession.js';
-import { saveSession, loadSession, clearSession } from '../services/sessionStorage.js';
+import { saveSession, loadSession, clearSession, saveReplaySession } from '../services/sessionStorage.js';
 
 export function useGameSession() {
   const sessionRef = useRef(null);
@@ -48,6 +48,9 @@ export function useGameSession() {
     session = completeSession(session);
     sessionRef.current = session;
     saveSession(session);
+    // Also persist to the replay key so the replay viewer can show this game
+    // even after the active session is overwritten by a new game.
+    saveReplaySession(session);
   }
 
   /** Replace the in-memory session and persist (used by undo). */

--- a/src/replay/ReplayApp.jsx
+++ b/src/replay/ReplayApp.jsx
@@ -87,7 +87,10 @@ export function ReplayApp() {
     if (!turn) return null;
     const evt = turn.events[stepIdx];
     if (!evt) return null;
-    return statesMap.get(evt.seq)?.score ?? null;
+    // WORDS_CLEARED shows the pre-clear grid, so show the pre-clear score too.
+    // seq values are dense integers, so seq-1 is always the prior state.
+    const seqToRead = evt.type === 'WORDS_CLEARED' ? evt.seq - 1 : evt.seq;
+    return statesMap.get(seqToRead)?.score ?? null;
   })();
 
   const canGoBack = turnIdx > 0 || stepIdx > 0;

--- a/src/replay/useReplaySession.js
+++ b/src/replay/useReplaySession.js
@@ -1,4 +1,4 @@
-import { loadSession } from '../services/sessionStorage.js';
+import { loadReplaySession } from '../services/sessionStorage.js';
 import { buildTurns, buildReplayStates, preClearGrid } from '../services/replayEngine.js';
 
 /**
@@ -11,7 +11,7 @@ import { buildTurns, buildReplayStates, preClearGrid } from '../services/replayE
  *   preClear  - (clearEvent) => 42-cell grid with matched cells flagged
  */
 export function useReplaySession() {
-  const session = loadSession();
+  const session = loadReplaySession();
 
   if (!session || !session.events?.length) {
     return { session, turns: [], statesMap: new Map(), preClear: () => [] };

--- a/src/services/gameSession.js
+++ b/src/services/gameSession.js
@@ -45,6 +45,8 @@ export function createSession(mode, initialQueue, initialGrid, initialBlocks) {
  * @param {number} ts - timestamp
  */
 export function appendEvent(session, type, payload, ts) {
+  // seq = events.length before append → dense 0-indexed integers (0, 1, 2, …).
+  // preClearGrid in replayEngine relies on this to look up seq-1 as "prior state".
   const event = { seq: session.events.length, type, payload: { ...payload }, ts };
   return {
     ...session,

--- a/src/services/replayEngine.js
+++ b/src/services/replayEngine.js
@@ -134,7 +134,8 @@ export function buildTurns(session) {
  * @returns {Array} 42-cell grid with matched cells flagged
  */
 export function preClearGrid(statesMap, clearEvent) {
-  // State before this event = state after the previous event (seq - 1), or initial (-1)
+  // seq values are dense 0-indexed integers (guaranteed by appendEvent), so seq-1
+  // is always the state after the immediately preceding event, or -1 for the initial state.
   const preState = statesMap.get(clearEvent.seq - 1) ?? statesMap.get(-1);
   if (!preState) return Array(GRID_SIZE).fill(null);
 

--- a/src/services/sessionStorage.js
+++ b/src/services/sessionStorage.js
@@ -4,6 +4,7 @@
  */
 
 const STORAGE_KEY = 'noodel_session_v1';
+const REPLAY_KEY = 'noodel_replay_v1';
 const CURRENT_SCHEMA_VERSION = 3;
 
 export function saveSession(session) {
@@ -31,6 +32,31 @@ export function loadSession() {
     if (session.schemaVersion !== CURRENT_SCHEMA_VERSION) return null;
     if (!session.sessionId || !session.gameMode || !Array.isArray(session.events)) return null;
 
+    return session;
+  } catch {
+    return null;
+  }
+}
+
+/** Save a completed session for the replay viewer. Separate from the active session. */
+export function saveReplaySession(session) {
+  try {
+    localStorage.setItem(REPLAY_KEY, JSON.stringify(session));
+  } catch (error) {
+    if (error.name !== 'QuotaExceededError' && error.name !== 'NS_ERROR_DOM_QUOTA_REACHED') {
+      console.warn('Failed to save replay session:', error);
+    }
+  }
+}
+
+/** Load the most recent completed session for the replay viewer. */
+export function loadReplaySession() {
+  try {
+    const stored = localStorage.getItem(REPLAY_KEY);
+    if (!stored) return null;
+    const session = JSON.parse(stored);
+    if (session.schemaVersion !== CURRENT_SCHEMA_VERSION) return null;
+    if (!session.sessionId || !session.gameMode || !Array.isArray(session.events)) return null;
     return session;
   } catch {
     return null;


### PR DESCRIPTION
## Summary

Stacked on #88 — merge that first, then update this PR's base to `main`.

### Docs (4 commits)
- **Design Decisions section in CLAUDE.md**: Documents timing constants, `PROCESSING` status behaviour, grace period classification rules, transitive BFS expiration, gravity concurrency guards, Clear mode scoring, and session event sourcing
- **Clear mode accuracy**: Removed reference to unimplemented `?betaClearModeEmptyBoard` flag; corrected win condition description to match actual code (full empty board required)
- **Code comments**: Clarified intentional score-overwrite in `REMOVE_WORDS` (Clear mode) and full-empty-board victory check in `useGameLogic`

### Replay system (5 commits)
- **Separate replay storage key** (`noodel_replay_v1`): Completed games are now saved to a dedicated key so the replay viewer survives the user starting a new game
- **Score/grid temporal mismatch fix**: Replay viewer was showing post-clear score while displaying the pre-clear grid during a `WORDS_CLEARED` step — now both are consistently pre-clear
- **seq contract documentation**: `appendEvent` and `preClearGrid` now document that `seq` values are dense 0-indexed integers, making the `seq-1` prior-state lookup explicit

## Test plan

- [ ] Play a complete game to GAME_OVER
- [ ] Open `/game_replay.html` — completed game is visible
- [ ] Start a new game, then return to `/game_replay.html` — completed game is still visible (not wiped)
- [ ] Step through a WORDS_CLEARED event — score matches the pre-clear board state
- [ ] `npm test` — all 74 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)