### PR TITLE
feat: user accounts, leaderboard with session replay, claude auto-play

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.2.1",
+        "concurrently": "^9.2.1",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "vite": "^5.0.8"
@@ -2548,6 +2549,47 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -5564,6 +5606,16 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -5703,6 +5755,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {
@@ -6049,6 +6114,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "start": "node server.js",
-    "dev": "vite",
+    "dev": "concurrently \"node server.js\" \"vite\"",
+    "dev:vite": "vite",
     "build": "vite build",
     "preview": "vite preview",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
@@ -31,6 +32,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.1",
+    "concurrently": "^9.2.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "vite": "^5.0.8"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --watch",
     "test:coverage": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage",
-    "migrate": "node scripts/migrate.js"
+    "migrate": "node scripts/migrate.js",
+    "claude:play": "node scripts/claude_play.js",
+    "claude:load": "node scripts/load_replay.js"
   },
   "engines": {
     "node": ">=18.0.0",

--- a/scripts/claude_play.js
+++ b/scripts/claude_play.js
@@ -1,0 +1,377 @@
+#!/usr/bin/env node
+/**
+ * Claude plays Noodel.
+ *
+ * Runs a full classic-mode game using the same game logic as the browser,
+ * records a valid event-sourced session, and writes it to:
+ *   scripts/claude_play_session.json
+ *
+ * To watch the replay:
+ *   node scripts/claude_play.js
+ *   Then paste the printed snippet into your browser console while
+ *   game_replay.html is open (or use npm start and open the page first).
+ */
+
+import { readFileSync } from 'fs';
+import { writeFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+
+// ─── Constants (mirrors gameConstants.js) ────────────────────────────────────
+
+const GRID_COLS = 7;
+const GRID_ROWS = 6;
+const GRID_SIZE = GRID_COLS * GRID_ROWS;
+const TOTAL_LETTERS = 100;
+
+// ─── Dictionary ───────────────────────────────────────────────────────────────
+
+function loadDictionary() {
+  const files = [
+    'public/words/3_letter_words.csv',
+    'public/words/4_letter_words.csv',
+    'public/words/5_letter_words.csv',
+    'public/words/6_letter_words.csv',
+    'public/words/7_letter_words.csv',
+  ];
+  const set = new Set();
+  for (const f of files) {
+    const lines = readFileSync(join(ROOT, f), 'utf8').split('\n');
+    for (const line of lines.slice(1)) { // skip header
+      const word = line.split(',')[0].trim().toUpperCase();
+      if (word) set.add(word);
+    }
+  }
+  return set;
+}
+
+// ─── Letter generation (mirrors letterUtils.js) ──────────────────────────────
+
+const LETTER_FREQUENCIES = [
+  ['E',12.70],['T',9.06],['A',8.17],['O',7.51],['I',6.97],['N',6.75],
+  ['S',6.33],['H',6.09],['R',5.99],['D',4.25],['L',4.03],['C',2.78],
+  ['U',2.76],['M',2.41],['W',2.36],['F',2.23],['G',2.02],['Y',1.97],
+  ['P',1.93],['B',1.29],['V',0.98],['K',0.77],['J',0.15],['X',0.15],
+  ['Q',0.10],['Z',0.07],
+];
+let _totalWeight = 0;
+const _cumWeights = LETTER_FREQUENCIES.map(([l, w]) => {
+  _totalWeight += w;
+  return [l, _totalWeight];
+});
+const VOWELS = new Set(['A','E','I','O','U']);
+
+function weightedRandom() {
+  const r = Math.random() * _totalWeight;
+  for (const [l, cw] of _cumWeights) if (r <= cw) return l;
+  return 'E';
+}
+
+function generateLetterSequence(count) {
+  const seq = [];
+  for (let i = 0; i < count; i++) {
+    const prev = seq.length ? seq[seq.length - 1].char : null;
+    const consRun = (() => {
+      let c = 0;
+      for (let j = seq.length - 1; j >= 0; j--) {
+        if (VOWELS.has(seq[j].char)) break;
+        c++;
+      }
+      return c;
+    })();
+    const mustVowel = consRun >= 3;
+    let letter;
+    for (let tries = 0; tries < 100; tries++) {
+      const c = weightedRandom();
+      if (c !== prev && (!mustVowel || VOWELS.has(c))) { letter = c; break; }
+    }
+    if (!letter) letter = mustVowel ? 'E' : 'T';
+    seq.push({ char: letter, id: `tile-${i}`, type: 'letter' });
+  }
+  return seq;
+}
+
+// ─── Word detection (mirrors wordUtils.js) ───────────────────────────────────
+
+function extractWord(grid, r, c, dr, dc, len) {
+  const letters = [], indices = [];
+  for (let i = 0; i < len; i++) {
+    const row = r + i * dr, col = c + i * dc;
+    const idx = row * GRID_COLS + col;
+    const cell = grid[idx];
+    if (!cell) return null;
+    letters.push(cell.char);
+    indices.push(idx);
+  }
+  const dir = dr === 0 ? 'horizontal' : 'vertical';
+  return { word: letters.join(''), indices, direction: dir };
+}
+
+function findWords(grid, dictionary) {
+  const found = [];
+  // horizontal
+  for (let r = 0; r < GRID_ROWS; r++)
+    for (let c = 0; c < GRID_COLS; c++)
+      for (let len = 3; len <= GRID_COLS - c; len++) {
+        const w = extractWord(grid, r, c, 0, 1, len);
+        if (w && dictionary.has(w.word)) found.push(w);
+      }
+  // vertical
+  for (let c = 0; c < GRID_COLS; c++)
+    for (let r = 0; r < GRID_ROWS; r++)
+      for (let len = 3; len <= GRID_ROWS - r; len++) {
+        const w = extractWord(grid, r, c, 1, 0, len);
+        if (w && dictionary.has(w.word)) found.push(w);
+      }
+  return found;
+}
+
+// ─── Scoring (mirrors scoringUtils.js) ───────────────────────────────────────
+
+const LETTER_VALUES = {
+  A:1,B:3,C:3,D:2,E:1,F:4,G:2,H:4,I:1,J:8,K:5,L:1,M:3,N:1,O:1,
+  P:3,Q:10,R:1,S:1,T:1,U:1,V:4,W:4,X:8,Y:4,Z:10,
+};
+const LENGTH_BONUSES = { 3:0, 4:1, 5:3, 6:4, 7:7 };
+
+function scoreWord(word) {
+  let s = 0;
+  for (const ch of word) s += LETTER_VALUES[ch] || 0;
+  return s + (LENGTH_BONUSES[word.length] || 0);
+}
+
+// ─── Game simulation ──────────────────────────────────────────────────────────
+
+function dropLetter(grid, col, tile) {
+  const newGrid = [...grid];
+  for (let row = GRID_ROWS - 1; row >= 0; row--) {
+    const idx = row * GRID_COLS + col;
+    if (!newGrid[idx]) {
+      newGrid[idx] = { ...tile, type: 'filled', isPending: false, isMatched: false, pendingDirections: [], isInitial: false };
+      return newGrid;
+    }
+  }
+  return null; // column full
+}
+
+function applyGravity(grid) {
+  const newGrid = Array(GRID_SIZE).fill(null);
+  for (let col = 0; col < GRID_COLS; col++) {
+    const cells = [];
+    for (let row = 0; row < GRID_ROWS; row++) {
+      const cell = grid[row * GRID_COLS + col];
+      if (cell) cells.push(cell);
+    }
+    for (let i = 0; i < cells.length; i++) {
+      newGrid[(GRID_ROWS - cells.length + i) * GRID_COLS + col] = {
+        ...cells[i], isPending: false, isMatched: false, pendingDirections: [], pendingResetCount: 0,
+      };
+    }
+  }
+  return newGrid;
+}
+
+function removeWords(grid, words) {
+  const newGrid = [...grid];
+  const toRemove = new Set(words.flatMap(w => w.indices));
+  toRemove.forEach(i => { newGrid[i] = null; });
+  return newGrid;
+}
+
+// Returns { grid, wordsCleared } after fully resolving cascades
+function resolveGrid(grid, dictionary) {
+  const allWordsCleared = [];
+  let chainId = 0;
+  let changed = true;
+  while (changed) {
+    changed = false;
+    const words = findWords(grid, dictionary);
+    if (words.length) {
+      allWordsCleared.push({ words, chainId });
+      grid = removeWords(grid, words);
+      grid = applyGravity(grid);
+      chainId++;
+      changed = true;
+    }
+  }
+  return { grid, allWordsCleared };
+}
+
+// ─── Claude's strategy ────────────────────────────────────────────────────────
+
+function columnHeight(grid, col) {
+  for (let row = 0; row < GRID_ROWS; row++) {
+    if (grid[row * GRID_COLS + col]) return GRID_ROWS - row;
+  }
+  return 0;
+}
+
+function countAdjacentTiles(grid, col) {
+  // How many existing tiles are adjacent (horizontally) to this column?
+  let score = 0;
+  for (let row = 0; row < GRID_ROWS; row++) {
+    if (col > 0 && grid[row * GRID_COLS + col - 1]) score++;
+    if (col < GRID_COLS - 1 && grid[row * GRID_COLS + col + 1]) score++;
+  }
+  return score;
+}
+
+function chooseColumn(grid, tile, dictionary) {
+  let bestCol = -1;
+  let bestScore = -Infinity;
+
+  for (let col = 0; col < GRID_COLS; col++) {
+    if (columnHeight(grid, col) >= GRID_ROWS) continue; // full
+
+    const newGrid = dropLetter(grid, col, tile);
+    const words = findWords(newGrid, dictionary);
+    const wordScore = words.reduce((s, w) => s + scoreWord(w.word), 0);
+
+    // Prefer: words formed, then adjacency (build clusters), then balanced height
+    const height = columnHeight(grid, col);
+    const adjacency = countAdjacentTiles(grid, col);
+    const balance = -height; // prefer shorter columns to keep board tidy
+
+    const total = wordScore * 100 + adjacency * 2 + balance;
+
+    if (total > bestScore) {
+      bestScore = total;
+      bestCol = col;
+    }
+  }
+
+  // Fallback: pick leftmost non-full column
+  if (bestCol === -1) {
+    for (let col = 0; col < GRID_COLS; col++) {
+      if (columnHeight(grid, col) < GRID_ROWS) { bestCol = col; break; }
+    }
+  }
+
+  return bestCol;
+}
+
+// ─── Session builder ──────────────────────────────────────────────────────────
+
+function generateSessionId() {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 11)}`;
+}
+
+function playGame(dictionary) {
+  const initialQueue = generateLetterSequence(TOTAL_LETTERS);
+  const now = Date.now();
+
+  const session = {
+    schemaVersion: 3,
+    sessionId: generateSessionId(),
+    gameMode: 'classic',
+    startedAt: now,
+    lastActivityAt: now,
+    status: 'in_progress',
+    initialQueue: initialQueue.map(t => ({ ...t })),
+    initialGrid: null,
+    initialBlocks: [],
+    events: [],
+    checkpoint: null,
+  };
+
+  let grid = Array(GRID_SIZE).fill(null);
+  let queue = [...initialQueue];
+  let score = 0;
+  let seq = 0;
+  let ts = now;
+  const madeWords = [];
+
+  function addEvent(type, payload) {
+    session.events.push({ seq: seq++, type, payload, ts: ts++ });
+    session.lastActivityAt = ts;
+  }
+
+  console.log('🤖 Claude is playing Noodel...\n');
+
+  while (queue.length > 0) {
+    const tile = queue.shift();
+    const col = chooseColumn(grid, tile, dictionary);
+
+    if (col === -1) {
+      console.log('Board is full — game over');
+      break;
+    }
+
+    addEvent('DROP_LETTER', { column: col, letter: tile.char });
+    grid = dropLetter(grid, col, tile);
+
+    const { grid: resolvedGrid, allWordsCleared } = resolveGrid(grid, dictionary);
+
+    for (const { words } of allWordsCleared) {
+      const wordObjs = words.map(w => ({
+        word: w.word,
+        indices: w.indices,
+        direction: w.direction,
+        chainId: 0,
+        comboDepth: 0,
+        groupSize: words.length,
+      }));
+      addEvent('WORDS_CLEARED', { words: wordObjs });
+      addEvent('GRAVITY', {});
+
+      for (const w of words) {
+        const ws = scoreWord(w.word);
+        score += ws;
+        madeWords.unshift({ word: w.word, score: ws, chainId: 0, comboDepth: 0 });
+        console.log(`  ✓ ${w.word.padEnd(8)} +${ws} pts  (col ${col}, ${w.direction})`);
+      }
+    }
+
+    grid = resolvedGrid;
+  }
+
+  // Build checkpoint (final state)
+  const lastSeq = session.events.length > 0 ? session.events[session.events.length - 1].seq : -1;
+  session.checkpoint = {
+    afterEventSeq: lastSeq,
+    grid: grid.map(cell => cell ? {
+      char: cell.char, id: cell.id, type: cell.type,
+      isMatched: false, isPending: false, pendingDirections: [],
+      pendingResetCount: 0, isInitial: false,
+    } : null),
+    nextQueue: queue,
+    lettersRemaining: queue.length,
+    score,
+    madeWords: madeWords.slice(0, 20),
+  };
+  session.status = 'completed';
+
+  return { session, score };
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+console.log('📖 Loading dictionary...');
+const dictionary = loadDictionary();
+console.log(`   ${dictionary.size.toLocaleString()} words loaded\n`);
+
+const { session, score } = playGame(dictionary);
+
+const outPath = join(__dirname, 'claude_play_session.json');
+writeFileSync(outPath, JSON.stringify(session, null, 2));
+
+const wordsFormed = session.events.filter(e => e.type === 'WORDS_CLEARED')
+  .reduce((sum, e) => sum + e.payload.words.length, 0);
+
+console.log(`\n🏁 Game over!`);
+console.log(`   Score      : ${score}`);
+console.log(`   Words found: ${wordsFormed}`);
+console.log(`   Turns taken: ${session.events.filter(e => e.type === 'DROP_LETTER').length}`);
+console.log(`\n📁 Session saved to: scripts/claude_play_session.json`);
+console.log(`\n👀 To watch the replay:`);
+console.log(`   1. Open http://localhost:3000/game_replay.html (run npm start first)`);
+console.log(`   2. Open the browser console and paste:\n`);
+
+const snippet = `const s = ${JSON.stringify(session).slice(0, 200)}...`;
+console.log(`   fetch('/api/scores').then(() => {});`);
+console.log(`   localStorage.setItem('noodel_replay_session', JSON.stringify(${JSON.stringify(session).length > 500 ? "/* session JSON */" : JSON.stringify(session)}));`);
+console.log(`   location.reload();\n`);
+console.log(`   (Or run: node scripts/load_replay.js  — it does this automatically via the server)\n`);

--- a/scripts/load_replay.js
+++ b/scripts/load_replay.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/**
+ * Loads claude_play_session.json into the running server as a leaderboard entry,
+ * then prints the URL to open in game_replay.html.
+ *
+ * Usage:
+ *   node scripts/load_replay.js
+ *
+ * Requires the server to be running (npm start or npm run dev + npm start).
+ */
+
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const session = JSON.parse(readFileSync(join(__dirname, 'claude_play_session.json'), 'utf8'));
+
+const score = session.checkpoint?.score ?? 0;
+
+const res = await fetch('http://localhost:3000/api/scores', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    score,
+    gameMode: session.gameMode,
+    username: 'claude',
+    sessionData: session,
+  }),
+});
+
+if (!res.ok) {
+  console.error('❌ Failed to upload session:', res.status, await res.text());
+  process.exit(1);
+}
+
+const row = await res.json();
+console.log(`✅ Session uploaded (score: ${score}, id: ${row.id})`);
+console.log(`\n👀 Open in browser:`);
+console.log(`   http://localhost:3000/game_replay.html`);
+console.log(`\n   Then open Settings → Leaderboard and click ▶ on the "claude" row.`);
+console.log(`\n   Or paste this into the browser console on that page:`);
+console.log(`\n   fetch('/api/scores/${row.id}/session').then(r=>r.json()).then(s=>{localStorage.setItem('noodel_replay_session',JSON.stringify(s));location.reload();})`);

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -5,18 +5,19 @@ import pg from 'pg';
 const { Pool } = pg;
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 
-const sql = `
-  CREATE TABLE IF NOT EXISTS leaderboard (
-    id         SERIAL PRIMARY KEY,
-    username   TEXT    NOT NULL DEFAULT 'anonymous',
-    score      INTEGER NOT NULL,
-    game_mode  TEXT    NOT NULL DEFAULT 'classic',
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-  );
-`;
-
 try {
-  await pool.query(sql);
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS leaderboard (
+      id           SERIAL PRIMARY KEY,
+      username     TEXT    NOT NULL DEFAULT 'anonymous',
+      score        INTEGER NOT NULL,
+      game_mode    TEXT    NOT NULL DEFAULT 'classic',
+      created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+  `);
+  await pool.query(`
+    ALTER TABLE leaderboard ADD COLUMN IF NOT EXISTS session_data JSONB;
+  `);
   console.log('✅ leaderboard table ready');
 } finally {
   await pool.end();

--- a/server.js
+++ b/server.js
@@ -36,20 +36,32 @@ app.use(express.static(DIST, {
 
 // Leaderboard API
 app.post('/api/scores', async (req, res) => {
-  const { score, gameMode } = req.body;
+  const { score, gameMode, username, sessionData } = req.body;
   if (typeof score !== 'number') return res.status(400).json({ error: 'score required' });
   const result = await pool.query(
-    'INSERT INTO leaderboard (score, game_mode) VALUES ($1, $2) RETURNING *',
-    [score, gameMode || 'classic']
+    'INSERT INTO leaderboard (score, game_mode, username, session_data) VALUES ($1, $2, $3, $4) RETURNING id, username, score, game_mode, created_at',
+    [score, gameMode || 'classic', username || 'anonymous', sessionData ? JSON.stringify(sessionData) : null]
   );
   res.status(201).json(result.rows[0]);
 });
 
 app.get('/api/scores', async (req, res) => {
   const result = await pool.query(
-    'SELECT * FROM leaderboard ORDER BY score DESC LIMIT 20'
+    'SELECT id, username, score, game_mode, created_at FROM leaderboard ORDER BY score DESC LIMIT 20'
   );
   res.json(result.rows);
+});
+
+app.get('/api/scores/:id/session', async (req, res) => {
+  const { id } = req.params;
+  const result = await pool.query(
+    'SELECT session_data FROM leaderboard WHERE id = $1',
+    [id]
+  );
+  if (!result.rows.length || !result.rows[0].session_data) {
+    return res.status(404).json({ error: 'session not found' });
+  }
+  res.json(result.rows[0].session_data);
 });
 
 // Handle SPA routing - serve dist/index.html for all other routes

--- a/server.js
+++ b/server.js
@@ -64,9 +64,12 @@ app.get('/api/scores/:id/session', async (req, res) => {
   res.json(result.rows[0].session_data);
 });
 
-// Handle SPA routing - serve dist/index.html for all other routes
+// Serve known HTML entry points directly; fall back to index.html for SPA routes
+const HTML_ENTRIES = ['index.html', 'poc.html', 'game_replay.html'];
 app.get('*', (req, res) => {
-  res.sendFile(path.join(DIST, 'index.html'));
+  const requested = path.basename(req.path);
+  const file = HTML_ENTRIES.includes(requested) ? requested : 'index.html';
+  res.sendFile(path.join(DIST, file));
 });
 
 app.listen(PORT, '0.0.0.0', () => {

--- a/src/components/Controls/SettingsMenu.jsx
+++ b/src/components/Controls/SettingsMenu.jsx
@@ -1,16 +1,51 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 
-/**
- * Settings menu - allows user to configure game and account settings
- * @param {boolean} visible - Whether the menu should be visible
- * @param {function} onClose - Callback when close button is clicked
- * @param {boolean} isMuted - Whether sound is muted
- * @param {function} onToggleMute - Callback to toggle mute state
- */
+const USERS = ['yiding', 'hannah'];
+
 function SettingsMenu({ visible, onClose, isMuted, onToggleMute }) {
   const isOnPoc = window.location.pathname.includes('poc.html');
   const switchTarget = isOnPoc ? '/noodel_new/' : '/noodel_new/poc.html';
-  const switchLabel = isOnPoc ? 'Switch to Classic' : 'Switch to New UI';
+
+  const [panel, setPanel] = useState(null); // null | 'login' | 'leaderboard'
+  const [currentUser, setCurrentUser] = useState(() => localStorage.getItem('noodel_username') ?? null);
+  const [scores, setScores] = useState([]);
+  const [loadingScores, setLoadingScores] = useState(false);
+
+  useEffect(() => {
+    if (!visible) setPanel(null);
+  }, [visible]);
+
+  function selectUser(name) {
+    localStorage.setItem('noodel_username', name);
+    setCurrentUser(name);
+    setPanel(null);
+  }
+
+  async function openLeaderboard() {
+    setPanel('leaderboard');
+    setLoadingScores(true);
+    try {
+      const res = await fetch('/api/scores');
+      const data = await res.json();
+      setScores(data);
+    } catch {
+      setScores([]);
+    } finally {
+      setLoadingScores(false);
+    }
+  }
+
+  async function handleReplay(scoreId) {
+    try {
+      const res = await fetch(`/api/scores/${scoreId}/session`);
+      if (!res.ok) { alert('No replay available for this score.'); return; }
+      const session = await res.json();
+      localStorage.setItem('noodel_replay_session', JSON.stringify(session));
+      window.open('/game_replay.html', '_blank');
+    } catch {
+      alert('Failed to load replay.');
+    }
+  }
 
   return (
     <div className={`mode-selection-menu settings-variant ${visible ? 'visible' : ''}`}>
@@ -24,31 +59,99 @@ function SettingsMenu({ visible, onClose, isMuted, onToggleMute }) {
         </button>
         <h2 className="mode-selection-title">Settings</h2>
 
-        <div className="mode-selection-section">
-          <div className="mode-selection-buttons">
-            <button className="mode-selection-btn settings-btn-item">
-              👤 Login
-            </button>
-            <button className="mode-selection-btn settings-btn-item">
-              📊 Stats
-            </button>
-            <button className="mode-selection-btn settings-btn-item">
-              🏆 Leaderboard
-            </button>
-            <button
-              className="mode-selection-btn settings-btn-item"
-              onClick={onToggleMute}
-            >
-              {isMuted ? '🔇 Unmute' : '🔊 Sound'}
-            </button>
-            <button
-              className="mode-selection-btn settings-btn-item"
-              onClick={() => { window.location.href = switchTarget; }}
-            >
-              {isOnPoc ? '🎮 Switch to Classic' : '✨ Switch to New UI'}
-            </button>
+        {panel === null && (
+          <div className="mode-selection-section">
+            <div className="mode-selection-buttons">
+              <button
+                className="mode-selection-btn settings-btn-item"
+                onClick={() => setPanel('login')}
+              >
+                👤 {currentUser ? `Logged in: ${currentUser}` : 'Login'}
+              </button>
+              <button className="mode-selection-btn settings-btn-item">
+                📊 Stats
+              </button>
+              <button
+                className="mode-selection-btn settings-btn-item"
+                onClick={openLeaderboard}
+              >
+                🏆 Leaderboard
+              </button>
+              <button
+                className="mode-selection-btn settings-btn-item"
+                onClick={onToggleMute}
+              >
+                {isMuted ? '🔇 Unmute' : '🔊 Sound'}
+              </button>
+              <button
+                className="mode-selection-btn settings-btn-item"
+                onClick={() => { window.location.href = switchTarget; }}
+              >
+                {isOnPoc ? '🎮 Switch to Classic' : '✨ Switch to New UI'}
+              </button>
+            </div>
           </div>
-        </div>
+        )}
+
+        {panel === 'login' && (
+          <div className="mode-selection-section">
+            <p className="mode-selection-subtitle">Select your name</p>
+            <div className="mode-selection-buttons">
+              {USERS.map(name => (
+                <button
+                  key={name}
+                  className={`mode-selection-btn settings-btn-item ${currentUser === name ? 'active' : ''}`}
+                  onClick={() => selectUser(name)}
+                >
+                  {currentUser === name ? '✓ ' : ''}{name.charAt(0).toUpperCase() + name.slice(1)}
+                </button>
+              ))}
+              <button
+                className="mode-selection-btn settings-btn-item"
+                onClick={() => setPanel(null)}
+              >
+                ← Back
+              </button>
+            </div>
+          </div>
+        )}
+
+        {panel === 'leaderboard' && (
+          <div className="mode-selection-section">
+            <p className="mode-selection-subtitle">Top Scores</p>
+            {loadingScores ? (
+              <p style={{ textAlign: 'center', padding: '1rem' }}>Loading...</p>
+            ) : scores.length === 0 ? (
+              <p style={{ textAlign: 'center', padding: '1rem' }}>No scores yet.</p>
+            ) : (
+              <div className="leaderboard-list">
+                {scores.map((row, i) => (
+                  <div key={row.id} className="leaderboard-row">
+                    <span className="leaderboard-rank">#{i + 1}</span>
+                    <span className="leaderboard-user">{row.username}</span>
+                    <span className="leaderboard-score">{row.score}</span>
+                    <span className="leaderboard-mode">{row.game_mode}</span>
+                    <button
+                      className="leaderboard-replay-btn"
+                      onClick={() => handleReplay(row.id)}
+                      title="Watch replay"
+                    >
+                      ▶
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+            <div className="mode-selection-buttons" style={{ marginTop: '1rem' }}>
+              <button
+                className="mode-selection-btn settings-btn-item"
+                onClick={() => setPanel(null)}
+              >
+                ← Back
+              </button>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/context/GameContext.jsx
+++ b/src/context/GameContext.jsx
@@ -85,11 +85,12 @@ export function GameProvider({ children }) {
   // Mark session complete and save score when game ends.
   useEffect(() => {
     if (state.status === 'GAME_OVER') {
-      gameSession.onGameOver(state);
+      const completedSession = gameSession.onGameOver(state);
+      const username = localStorage.getItem('noodel_username') ?? 'anonymous';
       fetch('/api/scores', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ score: state.score, gameMode: state.gameMode }),
+        body: JSON.stringify({ score: state.score, gameMode: state.gameMode, username, sessionData: completedSession }),
       }).catch(() => {}); // fire-and-forget; don't break the game on DB errors
     }
   }, [state.status]);

--- a/src/hooks/useGameSession.js
+++ b/src/hooks/useGameSession.js
@@ -41,16 +41,15 @@ export function useGameSession() {
     saveSession(sessionRef.current);
   }
 
-  /** Called when the game ends or reaches a stable rest point. */
+  /** Called when the game ends or reaches a stable rest point. Returns the completed session. */
   function onGameOver(state) {
-    if (!sessionRef.current) return;
+    if (!sessionRef.current) return null;
     let session = setCheckpoint(sessionRef.current, state);
     session = completeSession(session);
     sessionRef.current = session;
     saveSession(session);
-    // Also persist to the replay key so the replay viewer can show this game
-    // even after the active session is overwritten by a new game.
     saveReplaySession(session);
+    return session;
   }
 
   /** Replace the in-memory session and persist (used by undo). */

--- a/src/poc/styles/grid.css
+++ b/src/poc/styles/grid.css
@@ -480,3 +480,74 @@
     background: #FFECC8;   /* light orange indicates SETTINGS mode (orange) */
     border-color: var(--color-accent-secondary);   /* #FF9800 orange */
 }
+
+/* Leaderboard panel */
+.leaderboard-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    max-height: 260px;
+    overflow-y: auto;
+    padding: 4px 2px;
+}
+
+.leaderboard-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: rgba(255,255,255,0.6);
+    border-radius: 6px;
+    padding: 6px 10px;
+    font-size: 0.85rem;
+}
+
+.leaderboard-rank {
+    font-weight: bold;
+    color: #888;
+    min-width: 28px;
+}
+
+.leaderboard-user {
+    flex: 1;
+    font-weight: 600;
+    text-transform: capitalize;
+}
+
+.leaderboard-score {
+    font-weight: bold;
+    min-width: 40px;
+    text-align: right;
+}
+
+.leaderboard-mode {
+    color: #777;
+    font-size: 0.75rem;
+    min-width: 48px;
+    text-align: center;
+}
+
+.leaderboard-replay-btn {
+    background: var(--color-accent-secondary);
+    color: white;
+    border: none;
+    border-radius: 4px;
+    padding: 3px 8px;
+    cursor: pointer;
+    font-size: 0.8rem;
+}
+
+.leaderboard-replay-btn:hover {
+    opacity: 0.85;
+}
+
+.mode-selection-subtitle {
+    font-size: 0.85rem;
+    color: #666;
+    margin: 0 0 8px 0;
+    text-align: center;
+}
+
+.mode-selection-btn.active {
+    background: var(--color-accent-secondary);
+    color: white;
+}

--- a/src/replay/useReplaySession.js
+++ b/src/replay/useReplaySession.js
@@ -1,6 +1,19 @@
 import { loadReplaySession } from '../services/sessionStorage.js';
 import { buildTurns, buildReplayStates, preClearGrid } from '../services/replayEngine.js';
 
+function loadReplaySession() {
+  // Check for a leaderboard-triggered replay first (single-use).
+  try {
+    const stored = localStorage.getItem('noodel_replay_session');
+    if (stored) {
+      localStorage.removeItem('noodel_replay_session');
+      const session = JSON.parse(stored);
+      if (session?.sessionId && session?.events) return session;
+    }
+  } catch {}
+  return loadSession();
+}
+
 /**
  * Load the saved session and build all replay data in a single pass.
  *

--- a/src/replay/useReplaySession.js
+++ b/src/replay/useReplaySession.js
@@ -1,8 +1,9 @@
-import { loadReplaySession } from '../services/sessionStorage.js';
+import { useMemo } from 'react';
+import { loadReplaySession as loadLocalReplaySession } from '../services/sessionStorage.js';
 import { buildTurns, buildReplayStates, preClearGrid } from '../services/replayEngine.js';
 
 function loadReplaySession() {
-  // Check for a leaderboard-triggered replay first (single-use).
+  // Check for a leaderboard-triggered replay first (single-use key set by SettingsMenu).
   try {
     const stored = localStorage.getItem('noodel_replay_session');
     if (stored) {
@@ -11,11 +12,11 @@ function loadReplaySession() {
       if (session?.sessionId && session?.events) return session;
     }
   } catch {}
-  return loadSession();
+  return loadLocalReplaySession();
 }
 
 /**
- * Load the saved session and build all replay data in a single pass.
+ * Load the saved session and build all replay data once on mount.
  *
  * Returns:
  *   session   - raw session document (or null)
@@ -24,15 +25,18 @@ function loadReplaySession() {
  *   preClear  - (clearEvent) => 42-cell grid with matched cells flagged
  */
 export function useReplaySession() {
-  const session = loadReplaySession();
+  // useMemo with [] ensures we read localStorage exactly once, even across re-renders.
+  return useMemo(() => {
+    const session = loadReplaySession();
 
-  if (!session || !session.events?.length) {
-    return { session, turns: [], statesMap: new Map(), preClear: () => [] };
-  }
+    if (!session || !session.events?.length) {
+      return { session, turns: [], statesMap: new Map(), preClear: () => [] };
+    }
 
-  const turns = buildTurns(session);
-  const statesMap = buildReplayStates(session);
-  const preClear = (clearEvent) => preClearGrid(statesMap, clearEvent);
+    const turns = buildTurns(session);
+    const statesMap = buildReplayStates(session);
+    const preClear = (clearEvent) => preClearGrid(statesMap, clearEvent);
 
-  return { session, turns, statesMap, preClear };
+    return { session, turns, statesMap, preClear };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 }

--- a/src/styles/grid.css
+++ b/src/styles/grid.css
@@ -481,3 +481,74 @@
     background: #FFECC8;   /* light orange indicates SETTINGS mode (orange) */
     border-color: var(--color-accent-secondary);   /* #FF9800 orange */
 }
+
+/* Leaderboard panel */
+.leaderboard-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    max-height: 260px;
+    overflow-y: auto;
+    padding: 4px 2px;
+}
+
+.leaderboard-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: rgba(255,255,255,0.6);
+    border-radius: 6px;
+    padding: 6px 10px;
+    font-size: 0.85rem;
+}
+
+.leaderboard-rank {
+    font-weight: bold;
+    color: #888;
+    min-width: 28px;
+}
+
+.leaderboard-user {
+    flex: 1;
+    font-weight: 600;
+    text-transform: capitalize;
+}
+
+.leaderboard-score {
+    font-weight: bold;
+    min-width: 40px;
+    text-align: right;
+}
+
+.leaderboard-mode {
+    color: #777;
+    font-size: 0.75rem;
+    min-width: 48px;
+    text-align: center;
+}
+
+.leaderboard-replay-btn {
+    background: var(--color-accent-secondary);
+    color: white;
+    border: none;
+    border-radius: 4px;
+    padding: 3px 8px;
+    cursor: pointer;
+    font-size: 0.8rem;
+}
+
+.leaderboard-replay-btn:hover {
+    opacity: 0.85;
+}
+
+.mode-selection-subtitle {
+    font-size: 0.85rem;
+    color: #666;
+    margin: 0 0 8px 0;
+    text-align: center;
+}
+
+.mode-selection-btn.active {
+    background: var(--color-accent-secondary);
+    color: white;
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,6 +13,9 @@ export default defineConfig({
   server: {
     port: 5173,
     open: true,
+    proxy: {
+      '/api': 'http://localhost:3000',
+    },
   },
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary
- Add user picker (Yiding / Hannah) persisted to localStorage
- Leaderboard panel in settings showing top scores with replay button
- Store session data alongside scores; fetch and replay any game from leaderboard
- `claude_play.js` script that plays a full game and uploads a replayable session

## Test plan
- [ ] Settings → Login → select user → username persists across refresh
- [ ] Play a game to completion → score appears in leaderboard with correct username
- [ ] Click ▶ on a leaderboard row → `game_replay.html` opens and plays back the game
- [ ] `npm run claude:play && npm run claude:load` → "claude" row appears in leaderboard with working replay