### PR TITLE
fix: replay play button works immediately without needing right arrow first

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,34 @@ Events (DROP_LETTER, WORDS_CLEARED, GRAVITY) are recorded at the `wrappedDispatc
 
 In `REMOVE_WORDS`, Clear mode uses assignment (`totalScore = state.lettersRemaining`) not accumulation (`totalScore +=`). The final `score:` field is also set rather than added to. This means: your score equals the letters remaining at the time of your most recent clear, regardless of how many words cleared simultaneously. This is intentional — it creates a "beat the clock" feel where every drop costs potential score.
 
+### Replay overlay (`src/components/Replay/ReplayOverlay.jsx`)
+
+The leaderboard shows a ▶ button next to each score. Clicking it fetches the stored session from `GET /api/scores/:id/session` and mounts `ReplayOverlay` via a React Portal in `App.jsx`.
+
+**Frame pipeline** (all pure, no React hooks):
+
+1. `buildReplayStates(session)` — single-pass replay using `replayStep` + `gameReducer`, returns `Map<seq, state>` for every event (`replayEngine.js`)
+2. `buildTurns(session)` — groups events into turns: one `DROP_LETTER` + its trailing `WORDS_CLEARED`/`GRAVITY` events
+3. `pairClearGravity(turnEvents)` — pairs each `WORDS_CLEARED` with its following `GRAVITY` so settled frames use post-gravity state (no holes in grid)
+4. `buildFrames(turns, statesMap, preClearGrid)` — produces the final frame list
+
+**Frame sequence per turn** (mirrors actual game flow):
+
+| Frame | `isDropFrame` | `isMatchFrame` | Visual |
+|---|---|---|---|
+| Pre-drop | ✓ | — | Board before letter lands; `DroppingOverlay` animates |
+| Grace | — | ✓ | Words highlighted green (`isPending`) — one per `WORDS_CLEARED` |
+| Settled | — | — | Post-gravity state — one per `WORDS_CLEARED` |
+| Post-drop (no clear) | — | — | Board after letter lands, no word formed |
+
+**Pre-existing pending words**: Before each drop, words from the upcoming clear that are already fully formed (all tile indices non-null in the pre-drop grid) are pre-highlighted green on the drop frame — e.g. SIP is green while D is falling and about to form DIE.
+
+**Drop animation** (`DroppingOverlay`): positions are computed by measuring `.game-grid` via `boardRef.current.querySelector('.game-grid').getBoundingClientRect()` — same element `GameLayout` measures. `cellSize = Math.min(colWidth, rowHeight)` with horizontal centering offset matches the game exactly. The animation drives frame advancement via `onComplete`; the playback `setTimeout` skips drop frames.
+
+**Grace period CSS**: `--animation-duration-word-grace` is overridden on the board wrapper to `SPEEDS[speedIdx].ms * 0.5` so the `fillGreen` animation completes exactly as the frame transitions.
+
+**Score deduplication** (`GameContext.jsx`): `scoreSubmittedRef` guards the `POST /api/scores` call so React Strict Mode's double-mount doesn't submit two entries. Reset to `false` on each `START_GAME`.
+
 ## Database
 
 The app requires `DATABASE_URL` in `.env`. The `.env` file has two URLs (`LOCAL_DATABASE_URL`, `RAILWAY_DATABASE_URL`) — toggle which one `DATABASE_URL` points to.

--- a/scripts/claude_play_session.json
+++ b/scripts/claude_play_session.json
@@ -1,0 +1,2464 @@
+{
+  "schemaVersion": 3,
+  "sessionId": "mp96f1dw-3muv4b2d4",
+  "gameMode": "classic",
+  "startedAt": 1778986143428,
+  "lastActivityAt": 1778986143576,
+  "status": "completed",
+  "initialQueue": [
+    {
+      "char": "E",
+      "id": "tile-0",
+      "type": "letter"
+    },
+    {
+      "char": "R",
+      "id": "tile-1",
+      "type": "letter"
+    },
+    {
+      "char": "T",
+      "id": "tile-2",
+      "type": "letter"
+    },
+    {
+      "char": "H",
+      "id": "tile-3",
+      "type": "letter"
+    },
+    {
+      "char": "E",
+      "id": "tile-4",
+      "type": "letter"
+    },
+    {
+      "char": "A",
+      "id": "tile-5",
+      "type": "letter"
+    },
+    {
+      "char": "P",
+      "id": "tile-6",
+      "type": "letter"
+    },
+    {
+      "char": "L",
+      "id": "tile-7",
+      "type": "letter"
+    },
+    {
+      "char": "E",
+      "id": "tile-8",
+      "type": "letter"
+    },
+    {
+      "char": "S",
+      "id": "tile-9",
+      "type": "letter"
+    },
+    {
+      "char": "T",
+      "id": "tile-10",
+      "type": "letter"
+    },
+    {
+      "char": "A",
+      "id": "tile-11",
+      "type": "letter"
+    },
+    {
+      "char": "B",
+      "id": "tile-12",
+      "type": "letter"
+    },
+    {
+      "char": "G",
+      "id": "tile-13",
+      "type": "letter"
+    },
+    {
+      "char": "E",
+      "id": "tile-14",
+      "type": "letter"
+    },
+    {
+      "char": "S",
+      "id": "tile-15",
+      "type": "letter"
+    },
+    {
+      "char": "N",
+      "id": "tile-16",
+      "type": "letter"
+    },
+    {
+      "char": "P",
+      "id": "tile-17",
+      "type": "letter"
+    },
+    {
+      "char": "O",
+      "id": "tile-18",
+      "type": "letter"
+    },
+    {
+      "char": "T",
+      "id": "tile-19",
+      "type": "letter"
+    },
+    {
+      "char": "A",
+      "id": "tile-20",
+      "type": "letter"
+    },
+    {
+      "char": "E",
+      "id": "tile-21",
+      "type": "letter"
+    },
+    {
+      "char": "F",
+      "id": "tile-22",
+      "type": "letter"
+    },
+    {
+      "char": "O",
+      "id": "tile-23",
+      "type": "letter"
+    },
+    {
+      "char": "I",
+      "id": "tile-24",
+      "type": "letter"
+    },
+    {
+      "char": "T",
+      "id": "tile-25",
+      "type": "letter"
+    },
+    {
+      "char": "H",
+      "id": "tile-26",
+      "type": "letter"
+    },
+    {
+      "char": "A",
+      "id": "tile-27",
+      "type": "letter"
+    },
+    {
+      "char": "E",
+      "id": "tile-28",
+      "type": "letter"
+    },
+    {
+      "char": "A",
+      "id": "tile-29",
+      "type": "letter"
+    },
+    {
+      "char": "M",
+      "id": "tile-30",
+      "type": "letter"
+    },
+    {
+      "char": "N",
+      "id": "tile-31",
+      "type": "letter"
+    },
+    {
+      "char": "A",
+      "id": "tile-32",
+      "type": "letter"
+    },
+    {
+      "char": "D",
+      "id": "tile-33",
+      "type": "letter"
+    },
+    {
+      "char": "I",
+      "id": "tile-34",
+      "type": "letter"
+    },
+    {
+      "char": "O",
+      "id": "tile-35",
+      "type": "letter"
+    },
+    {
+      "char": "S",
+      "id": "tile-36",
+      "type": "letter"
+    },
+    {
+      "char": "E",
+      "id": "tile-37",
+      "type": "letter"
+    },
+    {
+      "char": "T",
+      "id": "tile-38",
+      "type": "letter"
+    },
+    {
+      "char": "G",
+      "id": "tile-39",
+      "type": "letter"
+    },
+    {
+      "char": "O",
+      "id": "tile-40",
+      "type": "letter"
+    },
+    {
+      "char": "A",
+      "id": "tile-41",
+      "type": "letter"
+    },
+    {
+      "char": "R",
+      "id": "tile-42",
+      "type": "letter"
+    },
+    {
+      "char": "Z",
+      "id": "tile-43",
+      "type": "letter"
+    },
+    {
+      "char": "D",
+      "id": "tile-44",
+      "type": "letter"
+    },
+    {
+      "char": "I",
+      "id": "tile-45",
+      "type": "letter"
+    },
+    {
+      "char": "S",
+      "id": "tile-46",
+      "type": "letter"
+    },
+    {
+      "char": "T",
+      "id": "tile-47",
+      "type": "letter"
+    },
+    {
+      "char": "N",
+      "id": "tile-48",
+      "type": "letter"
+    },
+    {
+      "char": "E",
+      "id": "tile-49",
+      "type": "letter"
+    },
+    {
+      "char": "W",
+      "id": "tile-50",
+      "type": "letter"
+    },
+    {
+      "char": "M",
+      "id": "tile-51",
+      "type": "letter"
+    },
+    {
+      "char": "N",
+      "id": "tile-52",
+      "type": "letter"
+    },
+    {
+      "char": "O",
+      "id": "tile-53",
+      "type": "letter"
+    },
+    {
+      "char": "N",
+      "id": "tile-54",
+      "type": "letter"
+    },
+    {
+      "char": "E",
+      "id": "tile-55",
+      "type": "letter"
+    },
+    {
+      "char": "S",
+      "id": "tile-56",
+      "type": "letter"
+    },
+    {
+      "char": "T",
+      "id": "tile-57",
+      "type": "letter"
+    },
+    {
+      "char": "G",
+      "id": "tile-58",
+      "type": "letter"
+    },
+    {
+      "char": "U",
+      "id": "tile-59",
+      "type": "letter"
+    },
+    {
+      "char": "W",
+      "id": "tile-60",
+      "type": "letter"
+    },
+    {
+      "char": "M",
+      "id": "tile-61",
+      "type": "letter"
+    },
+    {
+      "char": "R",
+      "id": "tile-62",
+      "type": "letter"
+    },
+    {
+      "char": "A",
+      "id": "tile-63",
+      "type": "letter"
+    },
+    {
+      "char": "T",
+      "id": "tile-64",
+      "type": "letter"
+    },
+    {
+      "char": "R",
+      "id": "tile-65",
+      "type": "letter"
+    },
+    {
+      "char": "E",
+      "id": "tile-66",
+      "type": "letter"
+    },
+    {
+      "char": "O",
+      "id": "tile-67",
+      "type": "letter"
+    },
+    {
+      "char": "I",
+      "id": "tile-68",
+      "type": "letter"
+    },
+    {
+      "char": "L",
+      "id": "tile-69",
+      "type": "letter"
+    },
+    {
+      "char": "S",
+      "id": "tile-70",
+      "type": "letter"
+    },
+    {
+      "char": "T",
+      "id": "tile-71",
+      "type": "letter"
+    },
+    {
+      "char": "O",
+      "id": "tile-72",
+      "type": "letter"
+    },
+    {
+      "char": "I",
+      "id": "tile-73",
+      "type": "letter"
+    },
+    {
+      "char": "R",
+      "id": "tile-74",
+      "type": "letter"
+    },
+    {
+      "char": "I",
+      "id": "tile-75",
+      "type": "letter"
+    },
+    {
+      "char": "N",
+      "id": "tile-76",
+      "type": "letter"
+    },
+    {
+      "char": "R",
+      "id": "tile-77",
+      "type": "letter"
+    },
+    {
+      "char": "D",
+      "id": "tile-78",
+      "type": "letter"
+    },
+    {
+      "char": "O",
+      "id": "tile-79",
+      "type": "letter"
+    },
+    {
+      "char": "R",
+      "id": "tile-80",
+      "type": "letter"
+    },
+    {
+      "char": "S",
+      "id": "tile-81",
+      "type": "letter"
+    },
+    {
+      "char": "E",
+      "id": "tile-82",
+      "type": "letter"
+    },
+    {
+      "char": "S",
+      "id": "tile-83",
+      "type": "letter"
+    },
+    {
+      "char": "N",
+      "id": "tile-84",
+      "type": "letter"
+    },
+    {
+      "char": "A",
+      "id": "tile-85",
+      "type": "letter"
+    },
+    {
+      "char": "S",
+      "id": "tile-86",
+      "type": "letter"
+    },
+    {
+      "char": "L",
+      "id": "tile-87",
+      "type": "letter"
+    },
+    {
+      "char": "D",
+      "id": "tile-88",
+      "type": "letter"
+    },
+    {
+      "char": "E",
+      "id": "tile-89",
+      "type": "letter"
+    },
+    {
+      "char": "I",
+      "id": "tile-90",
+      "type": "letter"
+    },
+    {
+      "char": "T",
+      "id": "tile-91",
+      "type": "letter"
+    },
+    {
+      "char": "I",
+      "id": "tile-92",
+      "type": "letter"
+    },
+    {
+      "char": "O",
+      "id": "tile-93",
+      "type": "letter"
+    },
+    {
+      "char": "A",
+      "id": "tile-94",
+      "type": "letter"
+    },
+    {
+      "char": "U",
+      "id": "tile-95",
+      "type": "letter"
+    },
+    {
+      "char": "E",
+      "id": "tile-96",
+      "type": "letter"
+    },
+    {
+      "char": "G",
+      "id": "tile-97",
+      "type": "letter"
+    },
+    {
+      "char": "O",
+      "id": "tile-98",
+      "type": "letter"
+    },
+    {
+      "char": "N",
+      "id": "tile-99",
+      "type": "letter"
+    }
+  ],
+  "initialGrid": null,
+  "initialBlocks": [],
+  "events": [
+    {
+      "seq": 0,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "E"
+      },
+      "ts": 1778986143428
+    },
+    {
+      "seq": 1,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 1,
+        "letter": "R"
+      },
+      "ts": 1778986143429
+    },
+    {
+      "seq": 2,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 2,
+        "letter": "T"
+      },
+      "ts": 1778986143430
+    },
+    {
+      "seq": 3,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 1,
+        "letter": "H"
+      },
+      "ts": 1778986143431
+    },
+    {
+      "seq": 4,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "E"
+      },
+      "ts": 1778986143432
+    },
+    {
+      "seq": 5,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 1,
+        "letter": "A"
+      },
+      "ts": 1778986143433
+    },
+    {
+      "seq": 6,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "P"
+      },
+      "ts": 1778986143434
+    },
+    {
+      "seq": 7,
+      "type": "WORDS_CLEARED",
+      "payload": {
+        "words": [
+          {
+            "word": "PEE",
+            "indices": [
+              21,
+              28,
+              35
+            ],
+            "direction": "vertical",
+            "chainId": 0,
+            "comboDepth": 0,
+            "groupSize": 1
+          }
+        ]
+      },
+      "ts": 1778986143435
+    },
+    {
+      "seq": 8,
+      "type": "GRAVITY",
+      "payload": {},
+      "ts": 1778986143436
+    },
+    {
+      "seq": 9,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "L"
+      },
+      "ts": 1778986143437
+    },
+    {
+      "seq": 10,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "E"
+      },
+      "ts": 1778986143438
+    },
+    {
+      "seq": 11,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 2,
+        "letter": "S"
+      },
+      "ts": 1778986143439
+    },
+    {
+      "seq": 12,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 1,
+        "letter": "T"
+      },
+      "ts": 1778986143440
+    },
+    {
+      "seq": 13,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "A"
+      },
+      "ts": 1778986143441
+    },
+    {
+      "seq": 14,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 1,
+        "letter": "B"
+      },
+      "ts": 1778986143442
+    },
+    {
+      "seq": 15,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "G"
+      },
+      "ts": 1778986143443
+    },
+    {
+      "seq": 16,
+      "type": "WORDS_CLEARED",
+      "payload": {
+        "words": [
+          {
+            "word": "GAEL",
+            "indices": [
+              14,
+              21,
+              28,
+              35
+            ],
+            "direction": "vertical",
+            "chainId": 0,
+            "comboDepth": 0,
+            "groupSize": 1
+          }
+        ]
+      },
+      "ts": 1778986143444
+    },
+    {
+      "seq": 17,
+      "type": "GRAVITY",
+      "payload": {},
+      "ts": 1778986143445
+    },
+    {
+      "seq": 18,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "E"
+      },
+      "ts": 1778986143446
+    },
+    {
+      "seq": 19,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "S"
+      },
+      "ts": 1778986143447
+    },
+    {
+      "seq": 20,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "N"
+      },
+      "ts": 1778986143448
+    },
+    {
+      "seq": 21,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 2,
+        "letter": "P"
+      },
+      "ts": 1778986143449
+    },
+    {
+      "seq": 22,
+      "type": "WORDS_CLEARED",
+      "payload": {
+        "words": [
+          {
+            "word": "NAP",
+            "indices": [
+              21,
+              22,
+              23
+            ],
+            "direction": "horizontal",
+            "chainId": 0,
+            "comboDepth": 0,
+            "groupSize": 2
+          },
+          {
+            "word": "PST",
+            "indices": [
+              23,
+              30,
+              37
+            ],
+            "direction": "vertical",
+            "chainId": 0,
+            "comboDepth": 0,
+            "groupSize": 2
+          }
+        ]
+      },
+      "ts": 1778986143450
+    },
+    {
+      "seq": 23,
+      "type": "GRAVITY",
+      "payload": {},
+      "ts": 1778986143451
+    },
+    {
+      "seq": 24,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 2,
+        "letter": "O"
+      },
+      "ts": 1778986143452
+    },
+    {
+      "seq": 25,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 3,
+        "letter": "T"
+      },
+      "ts": 1778986143453
+    },
+    {
+      "seq": 26,
+      "type": "WORDS_CLEARED",
+      "payload": {
+        "words": [
+          {
+            "word": "ROT",
+            "indices": [
+              36,
+              37,
+              38
+            ],
+            "direction": "horizontal",
+            "chainId": 0,
+            "comboDepth": 0,
+            "groupSize": 1
+          }
+        ]
+      },
+      "ts": 1778986143454
+    },
+    {
+      "seq": 27,
+      "type": "GRAVITY",
+      "payload": {},
+      "ts": 1778986143455
+    },
+    {
+      "seq": 28,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 2,
+        "letter": "A"
+      },
+      "ts": 1778986143456
+    },
+    {
+      "seq": 29,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 2,
+        "letter": "E"
+      },
+      "ts": 1778986143457
+    },
+    {
+      "seq": 30,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 1,
+        "letter": "F"
+      },
+      "ts": 1778986143458
+    },
+    {
+      "seq": 31,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 3,
+        "letter": "O"
+      },
+      "ts": 1778986143459
+    },
+    {
+      "seq": 32,
+      "type": "WORDS_CLEARED",
+      "payload": {
+        "words": [
+          {
+            "word": "HAO",
+            "indices": [
+              36,
+              37,
+              38
+            ],
+            "direction": "horizontal",
+            "chainId": 0,
+            "comboDepth": 0,
+            "groupSize": 1
+          }
+        ]
+      },
+      "ts": 1778986143460
+    },
+    {
+      "seq": 33,
+      "type": "GRAVITY",
+      "payload": {},
+      "ts": 1778986143461
+    },
+    {
+      "seq": 34,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 2,
+        "letter": "I"
+      },
+      "ts": 1778986143462
+    },
+    {
+      "seq": 35,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 2,
+        "letter": "T"
+      },
+      "ts": 1778986143463
+    },
+    {
+      "seq": 36,
+      "type": "WORDS_CLEARED",
+      "payload": {
+        "words": [
+          {
+            "word": "TIE",
+            "indices": [
+              23,
+              30,
+              37
+            ],
+            "direction": "vertical",
+            "chainId": 0,
+            "comboDepth": 0,
+            "groupSize": 1
+          }
+        ]
+      },
+      "ts": 1778986143464
+    },
+    {
+      "seq": 37,
+      "type": "GRAVITY",
+      "payload": {},
+      "ts": 1778986143465
+    },
+    {
+      "seq": 38,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 2,
+        "letter": "H"
+      },
+      "ts": 1778986143466
+    },
+    {
+      "seq": 39,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 2,
+        "letter": "A"
+      },
+      "ts": 1778986143467
+    },
+    {
+      "seq": 40,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 3,
+        "letter": "E"
+      },
+      "ts": 1778986143468
+    },
+    {
+      "seq": 41,
+      "type": "WORDS_CLEARED",
+      "payload": {
+        "words": [
+          {
+            "word": "THE",
+            "indices": [
+              36,
+              37,
+              38
+            ],
+            "direction": "horizontal",
+            "chainId": 0,
+            "comboDepth": 0,
+            "groupSize": 1
+          }
+        ]
+      },
+      "ts": 1778986143469
+    },
+    {
+      "seq": 42,
+      "type": "GRAVITY",
+      "payload": {},
+      "ts": 1778986143470
+    },
+    {
+      "seq": 43,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 3,
+        "letter": "A"
+      },
+      "ts": 1778986143471
+    },
+    {
+      "seq": 44,
+      "type": "WORDS_CLEARED",
+      "payload": {
+        "words": [
+          {
+            "word": "BAA",
+            "indices": [
+              36,
+              37,
+              38
+            ],
+            "direction": "horizontal",
+            "chainId": 0,
+            "comboDepth": 0,
+            "groupSize": 1
+          }
+        ]
+      },
+      "ts": 1778986143472
+    },
+    {
+      "seq": 45,
+      "type": "GRAVITY",
+      "payload": {},
+      "ts": 1778986143473
+    },
+    {
+      "seq": 46,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 1,
+        "letter": "M"
+      },
+      "ts": 1778986143474
+    },
+    {
+      "seq": 47,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 2,
+        "letter": "N"
+      },
+      "ts": 1778986143475
+    },
+    {
+      "seq": 48,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 1,
+        "letter": "A"
+      },
+      "ts": 1778986143476
+    },
+    {
+      "seq": 49,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 1,
+        "letter": "D"
+      },
+      "ts": 1778986143477
+    },
+    {
+      "seq": 50,
+      "type": "WORDS_CLEARED",
+      "payload": {
+        "words": [
+          {
+            "word": "DAM",
+            "indices": [
+              15,
+              22,
+              29
+            ],
+            "direction": "vertical",
+            "chainId": 0,
+            "comboDepth": 0,
+            "groupSize": 1
+          }
+        ]
+      },
+      "ts": 1778986143478
+    },
+    {
+      "seq": 51,
+      "type": "GRAVITY",
+      "payload": {},
+      "ts": 1778986143479
+    },
+    {
+      "seq": 52,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 1,
+        "letter": "I"
+      },
+      "ts": 1778986143480
+    },
+    {
+      "seq": 53,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 1,
+        "letter": "O"
+      },
+      "ts": 1778986143481
+    },
+    {
+      "seq": 54,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 2,
+        "letter": "S"
+      },
+      "ts": 1778986143482
+    },
+    {
+      "seq": 55,
+      "type": "WORDS_CLEARED",
+      "payload": {
+        "words": [
+          {
+            "word": "SIS",
+            "indices": [
+              28,
+              29,
+              30
+            ],
+            "direction": "horizontal",
+            "chainId": 0,
+            "comboDepth": 0,
+            "groupSize": 1
+          }
+        ]
+      },
+      "ts": 1778986143483
+    },
+    {
+      "seq": 56,
+      "type": "GRAVITY",
+      "payload": {},
+      "ts": 1778986143484
+    },
+    {
+      "seq": 57,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "E"
+      },
+      "ts": 1778986143485
+    },
+    {
+      "seq": 58,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "T"
+      },
+      "ts": 1778986143486
+    },
+    {
+      "seq": 59,
+      "type": "WORDS_CLEARED",
+      "payload": {
+        "words": [
+          {
+            "word": "TEE",
+            "indices": [
+              21,
+              28,
+              35
+            ],
+            "direction": "vertical",
+            "chainId": 0,
+            "comboDepth": 0,
+            "groupSize": 1
+          }
+        ]
+      },
+      "ts": 1778986143487
+    },
+    {
+      "seq": 60,
+      "type": "GRAVITY",
+      "payload": {},
+      "ts": 1778986143488
+    },
+    {
+      "seq": 61,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "G"
+      },
+      "ts": 1778986143489
+    },
+    {
+      "seq": 62,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "O"
+      },
+      "ts": 1778986143490
+    },
+    {
+      "seq": 63,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 1,
+        "letter": "A"
+      },
+      "ts": 1778986143491
+    },
+    {
+      "seq": 64,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 2,
+        "letter": "R"
+      },
+      "ts": 1778986143492
+    },
+    {
+      "seq": 65,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 1,
+        "letter": "Z"
+      },
+      "ts": 1778986143493
+    },
+    {
+      "seq": 66,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "D"
+      },
+      "ts": 1778986143494
+    },
+    {
+      "seq": 67,
+      "type": "WORDS_CLEARED",
+      "payload": {
+        "words": [
+          {
+            "word": "DOG",
+            "indices": [
+              21,
+              28,
+              35
+            ],
+            "direction": "vertical",
+            "chainId": 0,
+            "comboDepth": 0,
+            "groupSize": 1
+          }
+        ]
+      },
+      "ts": 1778986143495
+    },
+    {
+      "seq": 68,
+      "type": "GRAVITY",
+      "payload": {},
+      "ts": 1778986143496
+    },
+    {
+      "seq": 69,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "I"
+      },
+      "ts": 1778986143497
+    },
+    {
+      "seq": 70,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "S"
+      },
+      "ts": 1778986143498
+    },
+    {
+      "seq": 71,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "T"
+      },
+      "ts": 1778986143499
+    },
+    {
+      "seq": 72,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 2,
+        "letter": "N"
+      },
+      "ts": 1778986143500
+    },
+    {
+      "seq": 73,
+      "type": "WORDS_CLEARED",
+      "payload": {
+        "words": [
+          {
+            "word": "TAN",
+            "indices": [
+              21,
+              22,
+              23
+            ],
+            "direction": "horizontal",
+            "chainId": 0,
+            "comboDepth": 0,
+            "groupSize": 1
+          }
+        ]
+      },
+      "ts": 1778986143501
+    },
+    {
+      "seq": 74,
+      "type": "GRAVITY",
+      "payload": {},
+      "ts": 1778986143502
+    },
+    {
+      "seq": 75,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 1,
+        "letter": "E"
+      },
+      "ts": 1778986143503
+    },
+    {
+      "seq": 76,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "W"
+      },
+      "ts": 1778986143504
+    },
+    {
+      "seq": 77,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 1,
+        "letter": "M"
+      },
+      "ts": 1778986143505
+    },
+    {
+      "seq": 78,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 2,
+        "letter": "N"
+      },
+      "ts": 1778986143506
+    },
+    {
+      "seq": 79,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "O"
+      },
+      "ts": 1778986143507
+    },
+    {
+      "seq": 80,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "N"
+      },
+      "ts": 1778986143508
+    },
+    {
+      "seq": 81,
+      "type": "WORDS_CLEARED",
+      "payload": {
+        "words": [
+          {
+            "word": "NOW",
+            "indices": [
+              7,
+              14,
+              21
+            ],
+            "direction": "vertical",
+            "chainId": 0,
+            "comboDepth": 0,
+            "groupSize": 1
+          }
+        ]
+      },
+      "ts": 1778986143509
+    },
+    {
+      "seq": 82,
+      "type": "GRAVITY",
+      "payload": {},
+      "ts": 1778986143510
+    },
+    {
+      "seq": 83,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "E"
+      },
+      "ts": 1778986143511
+    },
+    {
+      "seq": 84,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "S"
+      },
+      "ts": 1778986143512
+    },
+    {
+      "seq": 85,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 2,
+        "letter": "T"
+      },
+      "ts": 1778986143513
+    },
+    {
+      "seq": 86,
+      "type": "WORDS_CLEARED",
+      "payload": {
+        "words": [
+          {
+            "word": "SET",
+            "indices": [
+              14,
+              15,
+              16
+            ],
+            "direction": "horizontal",
+            "chainId": 0,
+            "comboDepth": 0,
+            "groupSize": 1
+          }
+        ]
+      },
+      "ts": 1778986143514
+    },
+    {
+      "seq": 87,
+      "type": "GRAVITY",
+      "payload": {},
+      "ts": 1778986143515
+    },
+    {
+      "seq": 88,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "G"
+      },
+      "ts": 1778986143516
+    },
+    {
+      "seq": 89,
+      "type": "WORDS_CLEARED",
+      "payload": {
+        "words": [
+          {
+            "word": "GES",
+            "indices": [
+              14,
+              21,
+              28
+            ],
+            "direction": "vertical",
+            "chainId": 0,
+            "comboDepth": 0,
+            "groupSize": 1
+          }
+        ]
+      },
+      "ts": 1778986143517
+    },
+    {
+      "seq": 90,
+      "type": "GRAVITY",
+      "payload": {},
+      "ts": 1778986143518
+    },
+    {
+      "seq": 91,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "U"
+      },
+      "ts": 1778986143519
+    },
+    {
+      "seq": 92,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "W"
+      },
+      "ts": 1778986143520
+    },
+    {
+      "seq": 93,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 1,
+        "letter": "M"
+      },
+      "ts": 1778986143521
+    },
+    {
+      "seq": 94,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "R"
+      },
+      "ts": 1778986143522
+    },
+    {
+      "seq": 95,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 1,
+        "letter": "A"
+      },
+      "ts": 1778986143523
+    },
+    {
+      "seq": 96,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 2,
+        "letter": "T"
+      },
+      "ts": 1778986143524
+    },
+    {
+      "seq": 97,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "R"
+      },
+      "ts": 1778986143525
+    },
+    {
+      "seq": 98,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "E"
+      },
+      "ts": 1778986143526
+    },
+    {
+      "seq": 99,
+      "type": "WORDS_CLEARED",
+      "payload": {
+        "words": [
+          {
+            "word": "ERR",
+            "indices": [
+              0,
+              7,
+              14
+            ],
+            "direction": "vertical",
+            "chainId": 0,
+            "comboDepth": 0,
+            "groupSize": 1
+          }
+        ]
+      },
+      "ts": 1778986143527
+    },
+    {
+      "seq": 100,
+      "type": "GRAVITY",
+      "payload": {},
+      "ts": 1778986143528
+    },
+    {
+      "seq": 101,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "O"
+      },
+      "ts": 1778986143529
+    },
+    {
+      "seq": 102,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "I"
+      },
+      "ts": 1778986143530
+    },
+    {
+      "seq": 103,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 2,
+        "letter": "L"
+      },
+      "ts": 1778986143531
+    },
+    {
+      "seq": 104,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 3,
+        "letter": "S"
+      },
+      "ts": 1778986143532
+    },
+    {
+      "seq": 105,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 2,
+        "letter": "T"
+      },
+      "ts": 1778986143533
+    },
+    {
+      "seq": 106,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "O"
+      },
+      "ts": 1778986143534
+    },
+    {
+      "seq": 107,
+      "type": "WORDS_CLEARED",
+      "payload": {
+        "words": [
+          {
+            "word": "OAT",
+            "indices": [
+              0,
+              1,
+              2
+            ],
+            "direction": "horizontal",
+            "chainId": 0,
+            "comboDepth": 0,
+            "groupSize": 1
+          }
+        ]
+      },
+      "ts": 1778986143535
+    },
+    {
+      "seq": 108,
+      "type": "GRAVITY",
+      "payload": {},
+      "ts": 1778986143536
+    },
+    {
+      "seq": 109,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 1,
+        "letter": "I"
+      },
+      "ts": 1778986143537
+    },
+    {
+      "seq": 110,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "R"
+      },
+      "ts": 1778986143538
+    },
+    {
+      "seq": 111,
+      "type": "WORDS_CLEARED",
+      "payload": {
+        "words": [
+          {
+            "word": "RIO",
+            "indices": [
+              0,
+              7,
+              14
+            ],
+            "direction": "vertical",
+            "chainId": 0,
+            "comboDepth": 0,
+            "groupSize": 1
+          }
+        ]
+      },
+      "ts": 1778986143539
+    },
+    {
+      "seq": 112,
+      "type": "GRAVITY",
+      "payload": {},
+      "ts": 1778986143540
+    },
+    {
+      "seq": 113,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "I"
+      },
+      "ts": 1778986143541
+    },
+    {
+      "seq": 114,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 2,
+        "letter": "N"
+      },
+      "ts": 1778986143542
+    },
+    {
+      "seq": 115,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 3,
+        "letter": "R"
+      },
+      "ts": 1778986143543
+    },
+    {
+      "seq": 116,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 3,
+        "letter": "D"
+      },
+      "ts": 1778986143544
+    },
+    {
+      "seq": 117,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 3,
+        "letter": "O"
+      },
+      "ts": 1778986143545
+    },
+    {
+      "seq": 118,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 3,
+        "letter": "R"
+      },
+      "ts": 1778986143546
+    },
+    {
+      "seq": 119,
+      "type": "WORDS_CLEARED",
+      "payload": {
+        "words": [
+          {
+            "word": "ROD",
+            "indices": [
+              10,
+              17,
+              24
+            ],
+            "direction": "vertical",
+            "chainId": 0,
+            "comboDepth": 0,
+            "groupSize": 1
+          }
+        ]
+      },
+      "ts": 1778986143547
+    },
+    {
+      "seq": 120,
+      "type": "GRAVITY",
+      "payload": {},
+      "ts": 1778986143548
+    },
+    {
+      "seq": 121,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 3,
+        "letter": "S"
+      },
+      "ts": 1778986143549
+    },
+    {
+      "seq": 122,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 3,
+        "letter": "E"
+      },
+      "ts": 1778986143550
+    },
+    {
+      "seq": 123,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "S"
+      },
+      "ts": 1778986143551
+    },
+    {
+      "seq": 124,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 3,
+        "letter": "N"
+      },
+      "ts": 1778986143552
+    },
+    {
+      "seq": 125,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "A"
+      },
+      "ts": 1778986143553
+    },
+    {
+      "seq": 126,
+      "type": "WORDS_CLEARED",
+      "payload": {
+        "words": [
+          {
+            "word": "AIN",
+            "indices": [
+              0,
+              1,
+              2
+            ],
+            "direction": "horizontal",
+            "chainId": 0,
+            "comboDepth": 0,
+            "groupSize": 1
+          }
+        ]
+      },
+      "ts": 1778986143554
+    },
+    {
+      "seq": 127,
+      "type": "GRAVITY",
+      "payload": {},
+      "ts": 1778986143555
+    },
+    {
+      "seq": 128,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 1,
+        "letter": "S"
+      },
+      "ts": 1778986143556
+    },
+    {
+      "seq": 129,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 2,
+        "letter": "L"
+      },
+      "ts": 1778986143557
+    },
+    {
+      "seq": 130,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 4,
+        "letter": "D"
+      },
+      "ts": 1778986143558
+    },
+    {
+      "seq": 131,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 3,
+        "letter": "E"
+      },
+      "ts": 1778986143559
+    },
+    {
+      "seq": 132,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 0,
+        "letter": "I"
+      },
+      "ts": 1778986143560
+    },
+    {
+      "seq": 133,
+      "type": "WORDS_CLEARED",
+      "payload": {
+        "words": [
+          {
+            "word": "ISLE",
+            "indices": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "direction": "horizontal",
+            "chainId": 0,
+            "comboDepth": 0,
+            "groupSize": 1
+          }
+        ]
+      },
+      "ts": 1778986143561
+    },
+    {
+      "seq": 134,
+      "type": "GRAVITY",
+      "payload": {},
+      "ts": 1778986143562
+    },
+    {
+      "seq": 135,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 1,
+        "letter": "T"
+      },
+      "ts": 1778986143563
+    },
+    {
+      "seq": 136,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 2,
+        "letter": "I"
+      },
+      "ts": 1778986143564
+    },
+    {
+      "seq": 137,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 3,
+        "letter": "O"
+      },
+      "ts": 1778986143565
+    },
+    {
+      "seq": 138,
+      "type": "WORDS_CLEARED",
+      "payload": {
+        "words": [
+          {
+            "word": "ONE",
+            "indices": [
+              3,
+              10,
+              17
+            ],
+            "direction": "vertical",
+            "chainId": 0,
+            "comboDepth": 0,
+            "groupSize": 1
+          }
+        ]
+      },
+      "ts": 1778986143566
+    },
+    {
+      "seq": 139,
+      "type": "GRAVITY",
+      "payload": {},
+      "ts": 1778986143567
+    },
+    {
+      "seq": 140,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 3,
+        "letter": "A"
+      },
+      "ts": 1778986143568
+    },
+    {
+      "seq": 141,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 3,
+        "letter": "U"
+      },
+      "ts": 1778986143569
+    },
+    {
+      "seq": 142,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 3,
+        "letter": "E"
+      },
+      "ts": 1778986143570
+    },
+    {
+      "seq": 143,
+      "type": "WORDS_CLEARED",
+      "payload": {
+        "words": [
+          {
+            "word": "TIE",
+            "indices": [
+              1,
+              2,
+              3
+            ],
+            "direction": "horizontal",
+            "chainId": 0,
+            "comboDepth": 0,
+            "groupSize": 1
+          }
+        ]
+      },
+      "ts": 1778986143571
+    },
+    {
+      "seq": 144,
+      "type": "GRAVITY",
+      "payload": {},
+      "ts": 1778986143572
+    },
+    {
+      "seq": 145,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 1,
+        "letter": "G"
+      },
+      "ts": 1778986143573
+    },
+    {
+      "seq": 146,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 2,
+        "letter": "O"
+      },
+      "ts": 1778986143574
+    },
+    {
+      "seq": 147,
+      "type": "DROP_LETTER",
+      "payload": {
+        "column": 3,
+        "letter": "N"
+      },
+      "ts": 1778986143575
+    }
+  ],
+  "checkpoint": {
+    "afterEventSeq": 147,
+    "grid": [
+      null,
+      {
+        "char": "G",
+        "id": "tile-97",
+        "type": "filled",
+        "isMatched": false,
+        "isPending": false,
+        "pendingDirections": [],
+        "pendingResetCount": 0,
+        "isInitial": false
+      },
+      {
+        "char": "O",
+        "id": "tile-98",
+        "type": "filled",
+        "isMatched": false,
+        "isPending": false,
+        "pendingDirections": [],
+        "pendingResetCount": 0,
+        "isInitial": false
+      },
+      {
+        "char": "N",
+        "id": "tile-99",
+        "type": "filled",
+        "isMatched": false,
+        "isPending": false,
+        "pendingDirections": [],
+        "pendingResetCount": 0,
+        "isInitial": false
+      },
+      null,
+      null,
+      null,
+      {
+        "char": "S",
+        "id": "tile-83",
+        "type": "filled",
+        "isMatched": false,
+        "isPending": false,
+        "pendingDirections": [],
+        "pendingResetCount": 0,
+        "isInitial": false
+      },
+      {
+        "char": "M",
+        "id": "tile-61",
+        "type": "filled",
+        "isMatched": false,
+        "isPending": false,
+        "pendingDirections": [],
+        "pendingResetCount": 0,
+        "isInitial": false
+      },
+      {
+        "char": "L",
+        "id": "tile-69",
+        "type": "filled",
+        "isMatched": false,
+        "isPending": false,
+        "pendingDirections": [],
+        "pendingResetCount": 0,
+        "isInitial": false
+      },
+      {
+        "char": "U",
+        "id": "tile-95",
+        "type": "filled",
+        "isMatched": false,
+        "isPending": false,
+        "pendingDirections": [],
+        "pendingResetCount": 0,
+        "isInitial": false
+      },
+      null,
+      null,
+      null,
+      {
+        "char": "I",
+        "id": "tile-75",
+        "type": "filled",
+        "isMatched": false,
+        "isPending": false,
+        "pendingDirections": [],
+        "pendingResetCount": 0,
+        "isInitial": false
+      },
+      {
+        "char": "M",
+        "id": "tile-51",
+        "type": "filled",
+        "isMatched": false,
+        "isPending": false,
+        "pendingDirections": [],
+        "pendingResetCount": 0,
+        "isInitial": false
+      },
+      {
+        "char": "T",
+        "id": "tile-64",
+        "type": "filled",
+        "isMatched": false,
+        "isPending": false,
+        "pendingDirections": [],
+        "pendingResetCount": 0,
+        "isInitial": false
+      },
+      {
+        "char": "A",
+        "id": "tile-94",
+        "type": "filled",
+        "isMatched": false,
+        "isPending": false,
+        "pendingDirections": [],
+        "pendingResetCount": 0,
+        "isInitial": false
+      },
+      null,
+      null,
+      null,
+      {
+        "char": "W",
+        "id": "tile-60",
+        "type": "filled",
+        "isMatched": false,
+        "isPending": false,
+        "pendingDirections": [],
+        "pendingResetCount": 0,
+        "isInitial": false
+      },
+      {
+        "char": "Z",
+        "id": "tile-43",
+        "type": "filled",
+        "isMatched": false,
+        "isPending": false,
+        "pendingDirections": [],
+        "pendingResetCount": 0,
+        "isInitial": false
+      },
+      {
+        "char": "N",
+        "id": "tile-52",
+        "type": "filled",
+        "isMatched": false,
+        "isPending": false,
+        "pendingDirections": [],
+        "pendingResetCount": 0,
+        "isInitial": false
+      },
+      {
+        "char": "S",
+        "id": "tile-81",
+        "type": "filled",
+        "isMatched": false,
+        "isPending": false,
+        "pendingDirections": [],
+        "pendingResetCount": 0,
+        "isInitial": false
+      },
+      null,
+      null,
+      null,
+      {
+        "char": "U",
+        "id": "tile-59",
+        "type": "filled",
+        "isMatched": false,
+        "isPending": false,
+        "pendingDirections": [],
+        "pendingResetCount": 0,
+        "isInitial": false
+      },
+      {
+        "char": "O",
+        "id": "tile-35",
+        "type": "filled",
+        "isMatched": false,
+        "isPending": false,
+        "pendingDirections": [],
+        "pendingResetCount": 0,
+        "isInitial": false
+      },
+      {
+        "char": "R",
+        "id": "tile-42",
+        "type": "filled",
+        "isMatched": false,
+        "isPending": false,
+        "pendingDirections": [],
+        "pendingResetCount": 0,
+        "isInitial": false
+      },
+      {
+        "char": "R",
+        "id": "tile-77",
+        "type": "filled",
+        "isMatched": false,
+        "isPending": false,
+        "pendingDirections": [],
+        "pendingResetCount": 0,
+        "isInitial": false
+      },
+      null,
+      null,
+      null,
+      {
+        "char": "I",
+        "id": "tile-45",
+        "type": "filled",
+        "isMatched": false,
+        "isPending": false,
+        "pendingDirections": [],
+        "pendingResetCount": 0,
+        "isInitial": false
+      },
+      {
+        "char": "F",
+        "id": "tile-22",
+        "type": "filled",
+        "isMatched": false,
+        "isPending": false,
+        "pendingDirections": [],
+        "pendingResetCount": 0,
+        "isInitial": false
+      },
+      {
+        "char": "N",
+        "id": "tile-31",
+        "type": "filled",
+        "isMatched": false,
+        "isPending": false,
+        "pendingDirections": [],
+        "pendingResetCount": 0,
+        "isInitial": false
+      },
+      {
+        "char": "S",
+        "id": "tile-70",
+        "type": "filled",
+        "isMatched": false,
+        "isPending": false,
+        "pendingDirections": [],
+        "pendingResetCount": 0,
+        "isInitial": false
+      },
+      {
+        "char": "D",
+        "id": "tile-88",
+        "type": "filled",
+        "isMatched": false,
+        "isPending": false,
+        "pendingDirections": [],
+        "pendingResetCount": 0,
+        "isInitial": false
+      },
+      null,
+      null
+    ],
+    "nextQueue": [],
+    "lettersRemaining": 0,
+    "score": 104,
+    "madeWords": [
+      {
+        "word": "TIE",
+        "score": 3,
+        "chainId": 0,
+        "comboDepth": 0
+      },
+      {
+        "word": "ONE",
+        "score": 3,
+        "chainId": 0,
+        "comboDepth": 0
+      },
+      {
+        "word": "ISLE",
+        "score": 5,
+        "chainId": 0,
+        "comboDepth": 0
+      },
+      {
+        "word": "AIN",
+        "score": 3,
+        "chainId": 0,
+        "comboDepth": 0
+      },
+      {
+        "word": "ROD",
+        "score": 4,
+        "chainId": 0,
+        "comboDepth": 0
+      },
+      {
+        "word": "RIO",
+        "score": 3,
+        "chainId": 0,
+        "comboDepth": 0
+      },
+      {
+        "word": "OAT",
+        "score": 3,
+        "chainId": 0,
+        "comboDepth": 0
+      },
+      {
+        "word": "ERR",
+        "score": 3,
+        "chainId": 0,
+        "comboDepth": 0
+      },
+      {
+        "word": "GES",
+        "score": 4,
+        "chainId": 0,
+        "comboDepth": 0
+      },
+      {
+        "word": "SET",
+        "score": 3,
+        "chainId": 0,
+        "comboDepth": 0
+      },
+      {
+        "word": "NOW",
+        "score": 6,
+        "chainId": 0,
+        "comboDepth": 0
+      },
+      {
+        "word": "TAN",
+        "score": 3,
+        "chainId": 0,
+        "comboDepth": 0
+      },
+      {
+        "word": "DOG",
+        "score": 5,
+        "chainId": 0,
+        "comboDepth": 0
+      },
+      {
+        "word": "TEE",
+        "score": 3,
+        "chainId": 0,
+        "comboDepth": 0
+      },
+      {
+        "word": "SIS",
+        "score": 3,
+        "chainId": 0,
+        "comboDepth": 0
+      },
+      {
+        "word": "DAM",
+        "score": 6,
+        "chainId": 0,
+        "comboDepth": 0
+      },
+      {
+        "word": "BAA",
+        "score": 5,
+        "chainId": 0,
+        "comboDepth": 0
+      },
+      {
+        "word": "THE",
+        "score": 6,
+        "chainId": 0,
+        "comboDepth": 0
+      },
+      {
+        "word": "TIE",
+        "score": 3,
+        "chainId": 0,
+        "comboDepth": 0
+      },
+      {
+        "word": "HAO",
+        "score": 6,
+        "chainId": 0,
+        "comboDepth": 0
+      }
+    ]
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import { DebugOverlay } from './components/Debug/DebugOverlay.jsx';
 import ModeSelector from './components/Controls/ModeSelector.jsx';
 import SettingsMenu from './components/Controls/SettingsMenu.jsx';
 import GameOverOverlay from './components/Overlays/GameOverOverlay.jsx';
+import ReplayOverlay from './components/Replay/ReplayOverlay.jsx';
 import HowToPlayModal from './poc/HowToPlayModal.jsx';
 import { useGame } from './context/GameContext.jsx';
 import { useGameLogic } from './hooks/useGameLogic.js';
@@ -18,6 +19,7 @@ function App() {
   const [showModeSelector, setShowModeSelector] = useState(false);
   const [showSettingsMenu, setShowSettingsMenu] = useState(false);
   const [showHowToPlay, setShowHowToPlay] = useState(false);
+  const [replaySession, setReplaySession] = useState(null);
   const [pendingMode, setPendingMode] = useState(null);
   const { dropOrderMap, statsVisible, controlsVisible, boardVisible, fastForward } = useIntroSequence();
 
@@ -65,7 +67,7 @@ function App() {
     : false;
 
   return (
-    <div className={`app-root${(showModeSelector || showSettingsMenu) ? ' menu-open' : ''}`}>
+    <div className={`app-root${(showModeSelector || showSettingsMenu || replaySession) ? ' menu-open' : ''}`}>
       <GameLayout
         gridWrapperRef={gridWrapperRef}
         score={state.score}
@@ -104,7 +106,15 @@ function App() {
           onClose={() => setShowSettingsMenu(false)}
           isMuted={isMuted}
           onToggleMute={handleToggleMute}
+          onReplay={(session) => {
+            setShowSettingsMenu(false);
+            setReplaySession(session);
+          }}
         />,
+        gridWrapperRef.current
+      )}
+      {replaySession && gridWrapperRef.current && createPortal(
+        <ReplayOverlay session={replaySession} onClose={() => setReplaySession(null)} />,
         gridWrapperRef.current
       )}
       <GameOverOverlay

--- a/src/components/Controls/SettingsMenu.jsx
+++ b/src/components/Controls/SettingsMenu.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 
 const USERS = ['yiding', 'hannah'];
 
-function SettingsMenu({ visible, onClose, isMuted, onToggleMute }) {
+function SettingsMenu({ visible, onClose, isMuted, onToggleMute, onReplay }) {
   const isOnPoc = window.location.pathname.includes('poc.html');
   const switchTarget = isOnPoc ? '/noodel_new/' : '/noodel_new/poc.html';
 
@@ -40,8 +40,7 @@ function SettingsMenu({ visible, onClose, isMuted, onToggleMute }) {
       const res = await fetch(`/api/scores/${scoreId}/session`);
       if (!res.ok) { alert('No replay available for this score.'); return; }
       const session = await res.json();
-      localStorage.setItem('noodel_replay_session', JSON.stringify(session));
-      window.open('/game_replay.html', '_blank');
+      onReplay(session);
     } catch {
       alert('Failed to load replay.');
     }

--- a/src/components/Replay/ReplayOverlay.css
+++ b/src/components/Replay/ReplayOverlay.css
@@ -1,0 +1,190 @@
+.replay-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.replay-card {
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.3);
+  width: min(360px, 95vw);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.replay-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px 10px;
+  border-bottom: 1px solid #eee;
+}
+
+.replay-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #333;
+}
+
+.replay-score-badge {
+  font-size: 13px;
+  font-weight: 700;
+  color: #1976D2;
+}
+
+.replay-close-btn {
+  background: none;
+  border: none;
+  font-size: 18px;
+  color: #999;
+  cursor: pointer;
+  padding: 2px 6px;
+  line-height: 1;
+}
+
+.replay-close-btn:hover {
+  color: #333;
+}
+
+.replay-board-wrapper {
+  padding: 12px 16px;
+  display: flex;
+  justify-content: center;
+  flex: 1;
+  min-height: 0;
+}
+
+.replay-board-wrapper .game-grid {
+  pointer-events: none;
+}
+
+.replay-progress-bar-track {
+  height: 3px;
+  background: #eee;
+  margin: 0 16px;
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.replay-progress-bar-fill {
+  height: 100%;
+  background: #1976D2;
+  border-radius: 2px;
+  transition: width 0.3s ease;
+}
+
+.replay-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px 14px;
+  gap: 8px;
+}
+
+.replay-nav-btn {
+  background: none;
+  border: none;
+  font-size: 20px;
+  color: #1976D2;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 6px;
+  line-height: 1;
+  transition: opacity 0.15s;
+}
+
+.replay-nav-btn:disabled {
+  opacity: 0.25;
+  cursor: default;
+}
+
+.replay-nav-btn:not(:disabled):hover {
+  background: #e3f0ff;
+}
+
+.replay-play-btn {
+  background: #1976D2;
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  font-size: 14px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.replay-play-btn:hover {
+  background: #1565C0;
+}
+
+.replay-turn-info {
+  font-size: 12px;
+  color: #888;
+  text-align: center;
+  flex: 1;
+  white-space: nowrap;
+}
+
+.replay-speed-btn {
+  background: none;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 11px;
+  color: #666;
+  cursor: pointer;
+  padding: 3px 8px;
+  white-space: nowrap;
+}
+
+.replay-speed-btn:hover {
+  border-color: #1976D2;
+  color: #1976D2;
+}
+
+.replay-next-queue {
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px 16px 0;
+}
+
+.replay-next-chip {
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  background: #f0f0f0;
+  font-size: 13px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #555;
+}
+
+.replay-next-chip--next {
+  background: #1976D2;
+  color: #fff;
+  width: 28px;
+  height: 28px;
+  font-size: 15px;
+}
+
+.replay-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 0;
+  color: #aaa;
+  font-size: 14px;
+}

--- a/src/components/Replay/ReplayOverlay.jsx
+++ b/src/components/Replay/ReplayOverlay.jsx
@@ -282,7 +282,11 @@ export default function ReplayOverlay({ session, onClose }) {
                     setFrameIdx(0);
                     setPlaying(true);
                   } else {
-                    setPlaying(p => !p);
+                    const nextPlaying = !playing;
+                    setPlaying(nextPlaying);
+                    if (nextPlaying && replayData?.frames[frameIdx]?.isDropFrame) {
+                      setFrameIdx(i => Math.min(i + 1, totalFrames - 1));
+                    }
                   }
                 }}
                 aria-label={playing ? 'Pause' : (frameIdx >= totalFrames - 1 ? 'Restart' : 'Play')}

--- a/src/components/Replay/ReplayOverlay.jsx
+++ b/src/components/Replay/ReplayOverlay.jsx
@@ -1,0 +1,293 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import Board from '../Grid/Board.jsx';
+import DroppingOverlay from '../Grid/DroppingOverlay.jsx';
+import './ReplayOverlay.css';
+
+const SPEEDS = [
+  { label: 'Slow', ms: 1400 },
+  { label: 'Normal', ms: 800 },
+  { label: 'Fast', ms: 350 },
+];
+
+const COLS = 7;
+const ROWS = 6;
+
+function computeDestRow(grid, column) {
+  for (let row = ROWS - 1; row >= 0; row--) {
+    if (!grid[row * COLS + column]) return row;
+  }
+  return 0;
+}
+
+function computeDropPositions(boardRef, column, destRow) {
+  // Measure the inner game-grid element, not the wrapper, to match GameLayout's math exactly.
+  const gridEl = boardRef.current.querySelector('.game-grid');
+  const rect = (gridEl ?? boardRef.current).getBoundingClientRect();
+  const colWidth = rect.width / COLS;
+  const rowHeight = rect.height / ROWS;
+  const cellSize = Math.min(colWidth, rowHeight);
+  const colLeft = rect.left + column * colWidth + (colWidth - cellSize) / 2;
+  const toTop = { x: colLeft, y: rect.top };
+  const toFinal = { x: colLeft, y: rect.top + destRow * rowHeight };
+  return { from: toTop, toTop, toFinal, cellSize };
+}
+
+// Pair each WORDS_CLEARED in a turn with its following GRAVITY event.
+function pairClearGravity(turnEvents) {
+  const pairs = [];
+  for (let j = 0; j < turnEvents.length; j++) {
+    if (turnEvents[j].type === 'WORDS_CLEARED') {
+      const gravity = turnEvents.slice(j + 1).find(e => e.type === 'GRAVITY');
+      pairs.push({ clearEvent: turnEvents[j], gravityEvent: gravity ?? null });
+    }
+  }
+  return pairs;
+}
+
+function buildFrames(turns, statesMap, preClearGrid) {
+  const frames = [];
+  for (let i = 0; i < turns.length; i++) {
+    const turn = turns[i];
+    const dropState = statesMap.get(turn.dropSeq);
+    if (!dropState) continue;
+    const pairs = pairClearGravity(turn.events);
+
+    // Pre-drop frame: board before the letter lands; DroppingOverlay animates over this.
+    const preDropState = statesMap.get(turn.dropSeq - 1) ?? statesMap.get(-1);
+
+    // Highlight any words that were already fully formed before this drop (e.g. SIP pending
+    // when D is about to drop and form DIE — both clear together). A word is "pre-formed" if
+    // every one of its tile indices is non-null in the pre-drop grid.
+    let preDropGrid = preDropState.grid;
+    if (pairs.length > 0) {
+      const pendingGrid = [...preDropState.grid];
+      let hasPending = false;
+      for (const w of pairs[0].clearEvent.payload.words) {
+        if (w.indices.every(idx => preDropState.grid[idx] != null)) {
+          for (const idx of w.indices) {
+            if (pendingGrid[idx]) {
+              pendingGrid[idx] = { ...pendingGrid[idx], isPending: true, pendingDirections: [w.direction], pendingResetCount: 0 };
+              hasPending = true;
+            }
+          }
+        }
+      }
+      if (hasPending) preDropGrid = pendingGrid;
+    }
+
+    frames.push({
+      grid: preDropGrid,
+      score: preDropState.score,
+      nextQueue: preDropState.nextQueue ?? [],
+      isMatchFrame: false,
+      isDropFrame: true,
+      column: turn.column,
+      letter: turn.letter,
+      speedMultiplier: 0, // duration driven by animation, not timer
+      dropIndex: i,
+    });
+
+    if (pairs.length === 0) {
+      // No clear: just show the post-drop state.
+      frames.push({
+        grid: dropState.grid,
+        score: dropState.score,
+        nextQueue: dropState.nextQueue ?? [],
+        isMatchFrame: false,
+        speedMultiplier: 1.0,
+        dropIndex: i,
+      });
+    } else {
+      for (const { clearEvent, gravityEvent } of pairs) {
+        // Grace frame: word highlighted green, matching the in-game grace period.
+        const matchedGrid = preClearGrid(statesMap, clearEvent);
+        const preState = statesMap.get(clearEvent.seq - 1) ?? dropState;
+        frames.push({
+          grid: matchedGrid,
+          score: preState.score,
+          nextQueue: dropState.nextQueue ?? [],
+          isMatchFrame: true,
+          speedMultiplier: 0.5,
+          dropIndex: i,
+        });
+
+        // Settled frame: post-gravity (tiles cleared and gravity applied, no holes).
+        const settledSeq = gravityEvent ? gravityEvent.seq : clearEvent.seq;
+        const settledState = statesMap.get(settledSeq);
+        if (settledState) {
+          frames.push({
+            grid: settledState.grid,
+            score: settledState.score,
+            nextQueue: dropState.nextQueue ?? [],
+            isMatchFrame: false,
+            speedMultiplier: 0.5,
+            dropIndex: i,
+          });
+        }
+      }
+    }
+  }
+
+  return frames;
+}
+
+export default function ReplayOverlay({ session, onClose }) {
+  const [replayData, setReplayData] = useState(null);
+  const [frameIdx, setFrameIdx] = useState(0);
+  const [playing, setPlaying] = useState(true);
+  const [speedIdx, setSpeedIdx] = useState(1);
+  const boardRef = useRef(null);
+
+  useEffect(() => {
+    import('../../services/replayEngine.js').then(({ buildTurns, buildReplayStates, preClearGrid }) => {
+      const turns = buildTurns(session);
+      const statesMap = buildReplayStates(session);
+      const frames = buildFrames(turns, statesMap, preClearGrid);
+      setReplayData({ frames });
+    });
+  }, [session]);
+
+  useEffect(() => {
+    if (!playing || !replayData) return;
+    if (frameIdx >= replayData.frames.length - 1) { setPlaying(false); return; }
+    const frame = replayData.frames[frameIdx];
+    // Drop frames are advanced by the DroppingOverlay's onComplete, not by a timer.
+    if (frame.isDropFrame) return;
+    const t = setTimeout(() => setFrameIdx(i => i + 1), SPEEDS[speedIdx].ms * frame.speedMultiplier);
+    return () => clearTimeout(t);
+  }, [playing, frameIdx, replayData, speedIdx]);
+
+  const cycleSpeed = useCallback(() => setSpeedIdx(i => (i + 1) % SPEEDS.length), []);
+
+  const prev = useCallback(() => {
+    setPlaying(false);
+    setFrameIdx(i => Math.max(0, i - 1));
+  }, []);
+
+  const next = useCallback(() => {
+    setPlaying(false);
+    setFrameIdx(i => Math.min((replayData?.frames.length ?? 1) - 1, i + 1));
+  }, [replayData]);
+
+  const frame = replayData?.frames[frameIdx];
+  const totalFrames = replayData?.frames.length ?? 0;
+
+  const totalDrops = replayData ? (replayData.frames[replayData.frames.length - 1]?.dropIndex ?? 0) + 1 : 0;
+  const currentDrop = (frame?.dropIndex ?? 0) + 1;
+  const progress = totalDrops > 1 ? (currentDrop / totalDrops) * 100 : 0;
+
+  // CSS variable for the grace period fill animation duration — matches the frame hold time.
+  const graceDuration = `${SPEEDS[speedIdx].ms * 0.5}ms`;
+
+  const username = session?.checkpoint?.username ?? session?.username ?? '';
+  const gameMode = session?.checkpoint?.gameMode ?? session?.gameMode ?? 'classic';
+  const finalScore = session?.checkpoint?.score ?? 0;
+  const displayScore = gameMode === 'clear' ? finalScore : (frame?.score ?? 0);
+
+  // Compute drop animation props when on a drop frame and the board is mounted.
+  let dropOverlay = null;
+  if (frame?.isDropFrame && boardRef.current) {
+    const destRow = computeDestRow(frame.grid, frame.column);
+    const { from, toTop, toFinal, cellSize } = computeDropPositions(boardRef, frame.column, destRow);
+    dropOverlay = (
+      <DroppingOverlay
+        key={frameIdx}
+        id={frameIdx}
+        column={frame.column}
+        letter={frame.letter}
+        from={from}
+        toTop={toTop}
+        toFinal={toFinal}
+        cellSize={cellSize}
+        onComplete={() => { if (playing) setFrameIdx(i => i + 1); }}
+      />
+    );
+  }
+
+  return (
+    <div className="replay-backdrop" onClick={onClose}>
+      <div className="replay-card" onClick={e => e.stopPropagation()}>
+        <div className="replay-header">
+          <span className="replay-title">
+            {username ? `Watching: ${username}` : 'Replay'}
+          </span>
+          <span className="replay-score-badge">{displayScore} pts</span>
+          <button className="replay-close-btn" onClick={onClose} aria-label="Close">✕</button>
+        </div>
+
+        {!replayData ? (
+          <div className="replay-loading">Loading…</div>
+        ) : (
+          <>
+            <div className="replay-next-queue">
+              {(frame?.nextQueue ?? []).slice(0, 5).map((item, i) => (
+                <span
+                  key={i}
+                  className={`replay-next-chip${i === 0 ? ' replay-next-chip--next' : ''}`}
+                >
+                  {item.char}
+                </span>
+              ))}
+            </div>
+
+            <div
+              ref={boardRef}
+              className="replay-board-wrapper"
+              style={{ '--animation-duration-word-grace': graceDuration }}
+            >
+              <Board grid={frame?.grid ?? Array(42).fill(null)} visible />
+              {dropOverlay}
+            </div>
+
+            <div className="replay-progress-bar-track">
+              <div className="replay-progress-bar-fill" style={{ width: `${progress}%` }} />
+            </div>
+
+            <div className="replay-controls">
+              <button
+                className="replay-nav-btn"
+                onClick={prev}
+                disabled={frameIdx === 0}
+                aria-label="Previous"
+              >
+                ◀
+              </button>
+
+              <button
+                className="replay-play-btn"
+                onClick={() => {
+                  if (!playing && frameIdx >= totalFrames - 1) {
+                    setFrameIdx(0);
+                    setPlaying(true);
+                  } else {
+                    setPlaying(p => !p);
+                  }
+                }}
+                aria-label={playing ? 'Pause' : (frameIdx >= totalFrames - 1 ? 'Restart' : 'Play')}
+              >
+                {playing ? '⏸' : (frameIdx >= totalFrames - 1 ? '↩' : '▶')}
+              </button>
+
+              <button
+                className="replay-nav-btn"
+                onClick={next}
+                disabled={frameIdx >= totalFrames - 1}
+                aria-label="Next"
+              >
+                ▶
+              </button>
+
+              <span className="replay-turn-info">
+                {currentDrop} / {totalDrops}
+              </span>
+
+              <button className="replay-speed-btn" onClick={cycleSpeed}>
+                {SPEEDS[speedIdx].label}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Replay/ReplayOverlay.jsx
+++ b/src/components/Replay/ReplayOverlay.jsx
@@ -81,7 +81,7 @@ function buildFrames(turns, statesMap, preClearGrid) {
       const pendingGrid = [...preDropState.grid];
       let hasPending = false;
       for (const w of allClearedWords) {
-        if (w.indices.every(idx => preDropState.grid[idx] != null)) {
+        if (w.indices.every((idx, j) => preDropState.grid[idx]?.char === w.word[j])) {
           for (const idx of w.indices) {
             if (pendingGrid[idx] && !pendingGrid[idx].isPending) {
               pendingGrid[idx] = { ...pendingGrid[idx], isPending: true, pendingDirections: [w.direction], pendingResetCount: 0 };

--- a/src/components/Replay/ReplayOverlay.jsx
+++ b/src/components/Replay/ReplayOverlay.jsx
@@ -61,19 +61,22 @@ function buildFrames(turns, statesMap, preClearGrid) {
     // Pre-drop frame: board before the letter lands; DroppingOverlay animates over this.
     const preDropState = statesMap.get(turn.dropSeq - 1) ?? statesMap.get(-1);
 
-    // Highlight any words that were already fully formed before this drop (e.g. SIP pending
-    // when D is about to drop and form DIE — both clear together). A word is "pre-formed" if
-    // every one of its tile indices is non-null in the pre-drop grid.
+    // Highlight any words that were already fully formed before this drop. A word is
+    // "pre-formed" if every one of its tile indices is non-null in the pre-drop grid.
+    // Check ALL clear events in the turn — a pre-pending word may clear in pairs[1+]
+    // if it has no intersection with the word formed by this drop.
     let preDropGrid = preDropState.grid;
     if (pairs.length > 0) {
       const pendingGrid = [...preDropState.grid];
       let hasPending = false;
-      for (const w of pairs[0].clearEvent.payload.words) {
-        if (w.indices.every(idx => preDropState.grid[idx] != null)) {
-          for (const idx of w.indices) {
-            if (pendingGrid[idx]) {
-              pendingGrid[idx] = { ...pendingGrid[idx], isPending: true, pendingDirections: [w.direction], pendingResetCount: 0 };
-              hasPending = true;
+      for (const { clearEvent } of pairs) {
+        for (const w of clearEvent.payload.words) {
+          if (w.indices.every(idx => preDropState.grid[idx] != null)) {
+            for (const idx of w.indices) {
+              if (pendingGrid[idx]) {
+                pendingGrid[idx] = { ...pendingGrid[idx], isPending: true, pendingDirections: [w.direction], pendingResetCount: 0 };
+                hasPending = true;
+              }
             }
           }
         }
@@ -113,7 +116,7 @@ function buildFrames(turns, statesMap, preClearGrid) {
           score: preState.score,
           nextQueue: dropState.nextQueue ?? [],
           isMatchFrame: true,
-          speedMultiplier: 0.5,
+          graceMs: 1000,
           dropIndex: i,
         });
 
@@ -160,7 +163,8 @@ export default function ReplayOverlay({ session, onClose }) {
     const frame = replayData.frames[frameIdx];
     // Drop frames are advanced by the DroppingOverlay's onComplete, not by a timer.
     if (frame.isDropFrame) return;
-    const t = setTimeout(() => setFrameIdx(i => i + 1), SPEEDS[speedIdx].ms * frame.speedMultiplier);
+    const delay = frame.graceMs ?? SPEEDS[speedIdx].ms * frame.speedMultiplier;
+    const t = setTimeout(() => setFrameIdx(i => i + 1), delay);
     return () => clearTimeout(t);
   }, [playing, frameIdx, replayData, speedIdx]);
 
@@ -183,8 +187,8 @@ export default function ReplayOverlay({ session, onClose }) {
   const currentDrop = (frame?.dropIndex ?? 0) + 1;
   const progress = totalDrops > 1 ? (currentDrop / totalDrops) * 100 : 0;
 
-  // CSS variable for the grace period fill animation duration — matches the frame hold time.
-  const graceDuration = `${SPEEDS[speedIdx].ms * 0.5}ms`;
+  // CSS variable for the grace period fill animation — always 1s to match the real game.
+  const graceDuration = '1000ms';
 
   const username = session?.checkpoint?.username ?? session?.username ?? '';
   const gameMode = session?.checkpoint?.gameMode ?? session?.gameMode ?? 'classic';

--- a/src/components/Replay/ReplayOverlay.jsx
+++ b/src/components/Replay/ReplayOverlay.jsx
@@ -52,6 +52,17 @@ function pairClearGravity(turnEvents) {
 
 function buildFrames(turns, statesMap, preClearGrid) {
   const frames = [];
+
+  // All words ever cleared in the session — used for look-ahead pre-highlighting.
+  // A word is shown as pending on any drop frame where all its tiles were already
+  // on the board before that drop (including turns after the current one, since
+  // rapid multi-drops can push a word's WORDS_CLEARED into a later turn).
+  const allClearedWords = turns.flatMap(t =>
+    t.events
+      .filter(e => e.type === 'WORDS_CLEARED')
+      .flatMap(e => e.payload.words)
+  );
+
   for (let i = 0; i < turns.length; i++) {
     const turn = turns[i];
     const dropState = statesMap.get(turn.dropSeq);
@@ -61,22 +72,20 @@ function buildFrames(turns, statesMap, preClearGrid) {
     // Pre-drop frame: board before the letter lands; DroppingOverlay animates over this.
     const preDropState = statesMap.get(turn.dropSeq - 1) ?? statesMap.get(-1);
 
-    // Highlight any words that were already fully formed before this drop. A word is
-    // "pre-formed" if every one of its tile indices is non-null in the pre-drop grid.
-    // Check ALL clear events in the turn — a pre-pending word may clear in pairs[1+]
-    // if it has no intersection with the word formed by this drop.
+    // Pre-highlight any word whose tiles were all already on the board before this drop.
+    // Look across ALL turns (not just the current one) so words pending from rapid earlier
+    // drops are caught even when their WORDS_CLEARED event falls in a later turn.
+    // The all-non-null check naturally excludes words completed by this drop itself.
     let preDropGrid = preDropState.grid;
-    if (pairs.length > 0) {
+    {
       const pendingGrid = [...preDropState.grid];
       let hasPending = false;
-      for (const { clearEvent } of pairs) {
-        for (const w of clearEvent.payload.words) {
-          if (w.indices.every(idx => preDropState.grid[idx] != null)) {
-            for (const idx of w.indices) {
-              if (pendingGrid[idx]) {
-                pendingGrid[idx] = { ...pendingGrid[idx], isPending: true, pendingDirections: [w.direction], pendingResetCount: 0 };
-                hasPending = true;
-              }
+      for (const w of allClearedWords) {
+        if (w.indices.every(idx => preDropState.grid[idx] != null)) {
+          for (const idx of w.indices) {
+            if (pendingGrid[idx] && !pendingGrid[idx].isPending) {
+              pendingGrid[idx] = { ...pendingGrid[idx], isPending: true, pendingDirections: [w.direction], pendingResetCount: 0 };
+              hasPending = true;
             }
           }
         }

--- a/src/components/Replay/ReplayOverlay.jsx
+++ b/src/components/Replay/ReplayOverlay.jsx
@@ -19,7 +19,7 @@ function computeDestRow(grid, column) {
   return 0;
 }
 
-function computeDropPositions(boardRef, column, destRow) {
+function computeDropPositions(boardRef, nextUpRef, column, destRow) {
   // Measure the inner game-grid element, not the wrapper, to match GameLayout's math exactly.
   const gridEl = boardRef.current.querySelector('.game-grid');
   const rect = (gridEl ?? boardRef.current).getBoundingClientRect();
@@ -29,7 +29,13 @@ function computeDropPositions(boardRef, column, destRow) {
   const colLeft = rect.left + column * colWidth + (colWidth - cellSize) / 2;
   const toTop = { x: colLeft, y: rect.top };
   const toFinal = { x: colLeft, y: rect.top + destRow * rowHeight };
-  return { from: toTop, toTop, toFinal, cellSize };
+  // Use the preview chip's position as the animation origin, mirroring the real game.
+  let from = toTop;
+  if (nextUpRef?.current) {
+    const previewRect = nextUpRef.current.getBoundingClientRect();
+    from = { x: previewRect.left, y: previewRect.top };
+  }
+  return { from, toTop, toFinal, cellSize };
 }
 
 // Pair each WORDS_CLEARED in a turn with its following GRAVITY event.
@@ -137,6 +143,7 @@ export default function ReplayOverlay({ session, onClose }) {
   const [playing, setPlaying] = useState(true);
   const [speedIdx, setSpeedIdx] = useState(1);
   const boardRef = useRef(null);
+  const nextUpRef = useRef(null);
 
   useEffect(() => {
     import('../../services/replayEngine.js').then(({ buildTurns, buildReplayStates, preClearGrid }) => {
@@ -188,7 +195,7 @@ export default function ReplayOverlay({ session, onClose }) {
   let dropOverlay = null;
   if (frame?.isDropFrame && boardRef.current) {
     const destRow = computeDestRow(frame.grid, frame.column);
-    const { from, toTop, toFinal, cellSize } = computeDropPositions(boardRef, frame.column, destRow);
+    const { from, toTop, toFinal, cellSize } = computeDropPositions(boardRef, nextUpRef, frame.column, destRow);
     dropOverlay = (
       <DroppingOverlay
         key={frameIdx}
@@ -222,8 +229,10 @@ export default function ReplayOverlay({ session, onClose }) {
             <div className="replay-next-queue">
               {(frame?.nextQueue ?? []).slice(0, 5).map((item, i) => (
                 <span
+                  ref={i === 0 ? nextUpRef : null}
                   key={i}
                   className={`replay-next-chip${i === 0 ? ' replay-next-chip--next' : ''}`}
+                  style={i === 0 && frame?.isDropFrame ? { visibility: 'hidden' } : undefined}
                 >
                   {item.char}
                 </span>

--- a/src/context/GameContext.jsx
+++ b/src/context/GameContext.jsx
@@ -38,9 +38,11 @@ export function GameProvider({ children }) {
   const gameSession = useGameSession();
   const stateRef = useRef(state);
   stateRef.current = state;
+  const scoreSubmittedRef = useRef(false);
 
   const wrappedDispatch = useCallback((action) => {
     if (action.type === 'START_GAME') {
+      scoreSubmittedRef.current = false;
       const { mode } = action.payload;
       const initialQueue = buildInitialQueue(mode);
       const { grid: initialGrid, initialBlocks } = buildInitialGrid(mode);
@@ -84,7 +86,8 @@ export function GameProvider({ children }) {
 
   // Mark session complete and save score when game ends.
   useEffect(() => {
-    if (state.status === 'GAME_OVER') {
+    if (state.status === 'GAME_OVER' && !scoreSubmittedRef.current) {
+      scoreSubmittedRef.current = true;
       const completedSession = gameSession.onGameOver(state);
       const username = localStorage.getItem('noodel_username') ?? 'anonymous';
       fetch('/api/scores', {

--- a/src/services/replayEngine.js
+++ b/src/services/replayEngine.js
@@ -140,9 +140,16 @@ export function preClearGrid(statesMap, clearEvent) {
   if (!preState) return Array(GRID_SIZE).fill(null);
 
   const grid = [...preState.grid];
+  const dirMap = new Map();
   for (const w of clearEvent.payload.words) {
     for (const idx of w.indices) {
-      if (grid[idx]) grid[idx] = { ...grid[idx], isMatched: true };
+      if (!dirMap.has(idx)) dirMap.set(idx, new Set());
+      dirMap.get(idx).add(w.direction);
+    }
+  }
+  for (const [idx, dirs] of dirMap) {
+    if (grid[idx]) {
+      grid[idx] = { ...grid[idx], isPending: true, pendingDirections: [...dirs], pendingResetCount: 0 };
     }
   }
   return grid;

--- a/src/styles/grid.css
+++ b/src/styles/grid.css
@@ -231,17 +231,17 @@
         var(--color-text-muted) 100%
     );
     background-size: 200% 100%;
-    background-position: 100% 0;
-    animation: fillGreen var(--animation-duration-word-grace) linear forwards;
+    background-position: 0% 0;
+    animation: drainGreen var(--animation-duration-word-grace) linear forwards;
 }
 
-/* Grace Period Fill Animation - slowly turns green from left to right */
-@keyframes fillGreen {
+/* Grace Period Drain Animation - starts fully green, drains right as timer counts down */
+@keyframes drainGreen {
     0% {
-        background-position: 100% 0;
+        background-position: 0% 0;
     }
     100% {
-        background-position: 0% 0;
+        background-position: 100% 0;
     }
 }
 

--- a/src/styles/grid.css
+++ b/src/styles/grid.css
@@ -231,17 +231,17 @@
         var(--color-text-muted) 100%
     );
     background-size: 200% 100%;
-    background-position: 0% 0;
-    animation: drainGreen var(--animation-duration-word-grace) linear forwards;
+    background-position: 100% 0;
+    animation: fillGreen var(--animation-duration-word-grace) linear forwards;
 }
 
-/* Grace Period Drain Animation - starts fully green, drains right as timer counts down */
-@keyframes drainGreen {
+/* Grace Period Fill Animation - slowly turns green from left to right */
+@keyframes fillGreen {
     0% {
-        background-position: 0% 0;
+        background-position: 100% 0;
     }
     100% {
-        background-position: 100% 0;
+        background-position: 0% 0;
     }
 }
 


### PR DESCRIPTION
## Summary
- Clicking ▶ now resumes playback immediately, even when paused on a drop frame
- Previously the play button did nothing until the user clicked → first — drop frames are advanced by `DroppingOverlay.onComplete`, not the timer, so the timer bailed silently
- Fix: when toggling to playing on a drop frame, skip to frame + 1 so the timer can take over

## Test plan
- [ ] Open replay overlay, let it auto-play past the first drop frame
- [ ] Pause mid-replay, then click ▶ — should resume immediately
- [ ] Pause on a drop frame, click ▶ — should skip it and continue
- [ ] Verify drop animation still plays on initial load and after restart (↩)

🤖 Generated with [Claude Code](https://claude.com/claude-code)