### PR TITLE
feat: word history tracking, stats panel, and UI polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,3 +126,19 @@ The app requires `DATABASE_URL` in `.env`. The `.env` file has two URLs (`LOCAL_
 Run `npm run migrate` once to create the `leaderboard` table before starting the server locally.
 
 Local PostgreSQL (Homebrew): `brew services start postgresql@16`, connect at `postgresql://localhost:5432/noodel_dev`.
+
+## Git Workflow
+
+Branch naming: `feat/`, `fix/`, `chore/` prefixes. PRs target `main`. After merge, pull main and delete the branch.
+
+### Commit convention
+- One logical change per commit — keep commits atomic
+- Prefix: `feat:` (new behaviour), `fix:` (bug/polish), `chore:` (tooling/docs)
+- Never batch unrelated changes into one commit
+
+### Commit → PR → Merge flow
+1. Stage files by logical group and commit each atomically (`git add <specific files>`)
+2. `git push -u origin <branch>`
+3. `gh pr create --title "..." --base main`
+4. `gh pr merge --merge --delete-branch`
+5. `git checkout main && git pull`

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "start": "node server.js",
-    "dev": "concurrently \"node server.js\" \"vite\"",
+    "dev": "concurrently \"node --watch server.js\" \"vite\"",
     "dev:vite": "vite",
     "build": "vite build",
     "preview": "vite preview",

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -19,6 +19,21 @@ try {
     ALTER TABLE leaderboard ADD COLUMN IF NOT EXISTS session_data JSONB;
   `);
   console.log('✅ leaderboard table ready');
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS word_history (
+      id            SERIAL PRIMARY KEY,
+      username      TEXT    NOT NULL,
+      word          TEXT    NOT NULL,
+      times_made    INTEGER NOT NULL DEFAULT 1,
+      first_made_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      last_made_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE (username, word)
+    );
+  `);
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS word_history_username_idx ON word_history (username);
+  `);
+  console.log('✅ word_history table ready');
 } finally {
   await pool.end();
 }

--- a/server.js
+++ b/server.js
@@ -80,7 +80,7 @@ app.post('/api/scores', async (req, res) => {
 
 app.get('/api/scores', async (req, res) => {
   const result = await pool.query(
-    'SELECT id, username, score, game_mode, created_at FROM leaderboard ORDER BY score DESC LIMIT 20'
+    'SELECT id, username, score, game_mode, created_at FROM leaderboard ORDER BY score DESC LIMIT 10'
   );
   res.json(result.rows);
 });
@@ -99,10 +99,14 @@ app.get('/api/scores/:id/session', async (req, res) => {
 
 app.get('/api/user-stats', async (req, res) => {
   const username = req.query.username || 'anonymous';
-  const [sizeResult, topWordsResult, worldFirstsResult] = await Promise.all([
+  const [sizeResult, topWordsResult, rareWordsResult, worldFirstsResult] = await Promise.all([
     pool.query('SELECT COUNT(*)::int AS count FROM word_history WHERE username = $1', [username]),
     pool.query(
-      'SELECT word, times_made FROM word_history WHERE username = $1 ORDER BY times_made DESC LIMIT 10',
+      'SELECT word, times_made FROM word_history WHERE username = $1 ORDER BY times_made DESC LIMIT 5',
+      [username]
+    ),
+    pool.query(
+      'SELECT word, times_made FROM word_history WHERE username = $1 ORDER BY times_made ASC LIMIT 5',
       [username]
     ),
     pool.query(
@@ -112,13 +116,14 @@ app.get('/api/user-stats', async (req, res) => {
            SELECT 1 FROM word_history wh2
            WHERE wh2.word = wh.word AND wh2.username != $1
          )
-       ORDER BY wh.times_made DESC`,
+       ORDER BY wh.times_made DESC LIMIT 5`,
       [username]
     ),
   ]);
   res.json({
     vocabularySize: sizeResult.rows[0].count,
     topWords: topWordsResult.rows.map(r => ({ word: r.word, timesMade: r.times_made })),
+    rareWords: rareWordsResult.rows.map(r => ({ word: r.word, timesMade: r.times_made })),
     worldFirsts: worldFirstsResult.rows.map(r => r.word),
   });
 });

--- a/server.js
+++ b/server.js
@@ -36,13 +36,46 @@ app.use(express.static(DIST, {
 
 // Leaderboard API
 app.post('/api/scores', async (req, res) => {
-  const { score, gameMode, username, sessionData } = req.body;
+  const { score, gameMode, username, sessionData, wordsCleared } = req.body;
   if (typeof score !== 'number') return res.status(400).json({ error: 'score required' });
+  const user = username || 'anonymous';
   const result = await pool.query(
     'INSERT INTO leaderboard (score, game_mode, username, session_data) VALUES ($1, $2, $3, $4) RETURNING id, username, score, game_mode, created_at',
-    [score, gameMode || 'classic', username || 'anonymous', sessionData ? JSON.stringify(sessionData) : null]
+    [score, gameMode || 'classic', user, sessionData ? JSON.stringify(sessionData) : null]
   );
-  res.status(201).json(result.rows[0]);
+
+  let wordStats = null;
+  const words = Array.isArray(wordsCleared) && wordsCleared.length > 0 ? wordsCleared : null;
+  if (words) {
+    await pool.query(
+      `INSERT INTO word_history (username, word, times_made, first_made_at, last_made_at)
+       SELECT $1, unnest($2::text[]), 1, NOW(), NOW()
+       ON CONFLICT (username, word) DO UPDATE
+         SET times_made = word_history.times_made + 1,
+             last_made_at = NOW()`,
+      [user, words]
+    );
+    const [sizeResult, rarestResult, worldFirstsResult] = await Promise.all([
+      pool.query('SELECT COUNT(*)::int AS count FROM word_history WHERE username = $1', [user]),
+      pool.query(
+        'SELECT word, times_made FROM word_history WHERE username = $1 AND word = ANY($2::text[]) ORDER BY times_made ASC LIMIT 1',
+        [user, words]
+      ),
+      pool.query(
+        'SELECT word FROM word_history WHERE word = ANY($1::text[]) GROUP BY word HAVING COUNT(DISTINCT username) = 1',
+        [words]
+      ),
+    ]);
+    wordStats = {
+      vocabularySize: sizeResult.rows[0].count,
+      rarestWord: rarestResult.rows[0]
+        ? { word: rarestResult.rows[0].word, timesThisUser: rarestResult.rows[0].times_made }
+        : null,
+      worldFirsts: worldFirstsResult.rows.map(r => r.word),
+    };
+  }
+
+  res.status(201).json({ ...result.rows[0], wordStats });
 });
 
 app.get('/api/scores', async (req, res) => {
@@ -62,6 +95,32 @@ app.get('/api/scores/:id/session', async (req, res) => {
     return res.status(404).json({ error: 'session not found' });
   }
   res.json(result.rows[0].session_data);
+});
+
+app.get('/api/user-stats', async (req, res) => {
+  const username = req.query.username || 'anonymous';
+  const [sizeResult, topWordsResult, worldFirstsResult] = await Promise.all([
+    pool.query('SELECT COUNT(*)::int AS count FROM word_history WHERE username = $1', [username]),
+    pool.query(
+      'SELECT word, times_made FROM word_history WHERE username = $1 ORDER BY times_made DESC LIMIT 10',
+      [username]
+    ),
+    pool.query(
+      `SELECT wh.word FROM word_history wh
+       WHERE wh.username = $1
+         AND NOT EXISTS (
+           SELECT 1 FROM word_history wh2
+           WHERE wh2.word = wh.word AND wh2.username != $1
+         )
+       ORDER BY wh.times_made DESC`,
+      [username]
+    ),
+  ]);
+  res.json({
+    vocabularySize: sizeResult.rows[0].count,
+    topWords: topWordsResult.rows.map(r => ({ word: r.word, timesMade: r.times_made })),
+    worldFirsts: worldFirstsResult.rows.map(r => r.word),
+  });
 });
 
 // Serve known HTML entry points directly; fall back to index.html for SPA routes

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -114,6 +114,7 @@ function App() {
         score={state.score}
         lettersRemaining={state.lettersRemaining}
         boardCleared={boardCleared}
+        wordStats={state.wordStats}
         onRestart={handleRestart}
       />
       {showHowToPlay && <HowToPlayModal onClose={() => setShowHowToPlay(false)} />}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -98,7 +98,7 @@ function App() {
         />,
         gridWrapperRef.current
       )}
-      {gridWrapperRef.current && createPortal(
+      {createPortal(
         <SettingsMenu
           visible={showSettingsMenu}
           onClose={() => setShowSettingsMenu(false)}
@@ -106,7 +106,7 @@ function App() {
           onToggleMute={handleToggleMute}
           onPlayReplay={setReplaySession}
         />,
-        gridWrapperRef.current
+        document.body
       )}
       <GameOverOverlay
         visible={state.status === 'GAME_OVER'}

--- a/src/components/Controls/SettingsMenu.jsx
+++ b/src/components/Controls/SettingsMenu.jsx
@@ -10,6 +10,8 @@ function SettingsMenu({ visible, onClose, isMuted, onToggleMute, onPlayReplay })
   const [currentUser, setCurrentUser] = useState(() => localStorage.getItem('noodel_username') ?? null);
   const [scores, setScores] = useState([]);
   const [loadingScores, setLoadingScores] = useState(false);
+  const [stats, setStats] = useState(null);
+  const [loadingStats, setLoadingStats] = useState(false);
 
   useEffect(() => {
     if (!visible) setPanel(null);
@@ -19,6 +21,20 @@ function SettingsMenu({ visible, onClose, isMuted, onToggleMute, onPlayReplay })
     localStorage.setItem('noodel_username', name);
     setCurrentUser(name);
     setPanel(null);
+  }
+
+  async function openStats() {
+    setPanel('stats');
+    setLoadingStats(true);
+    try {
+      const username = localStorage.getItem('noodel_username') ?? 'anonymous';
+      const res = await fetch(`/api/user-stats?username=${encodeURIComponent(username)}`);
+      setStats(await res.json());
+    } catch {
+      setStats(null);
+    } finally {
+      setLoadingStats(false);
+    }
   }
 
   async function openLeaderboard() {
@@ -73,7 +89,7 @@ function SettingsMenu({ visible, onClose, isMuted, onToggleMute, onPlayReplay })
               >
                 👤 {currentUser ? `Logged in: ${currentUser}` : 'Login'}
               </button>
-              <button className="mode-selection-btn settings-btn-item">
+              <button className="mode-selection-btn settings-btn-item" onClick={openStats}>
                 📊 Stats
               </button>
               <button
@@ -115,6 +131,50 @@ function SettingsMenu({ visible, onClose, isMuted, onToggleMute, onPlayReplay })
                 className="mode-selection-btn settings-btn-item"
                 onClick={() => setPanel(null)}
               >
+                ← Back
+              </button>
+            </div>
+          </div>
+        )}
+
+        {panel === 'stats' && (
+          <div className="mode-selection-section">
+            <p className="mode-selection-subtitle">
+              {currentUser ? `${currentUser}'s Stats` : 'Your Stats'}
+            </p>
+            {loadingStats ? (
+              <p style={{ textAlign: 'center', padding: '1rem' }}>Loading...</p>
+            ) : !stats || stats.vocabularySize === 0 ? (
+              <p style={{ textAlign: 'center', padding: '1rem' }}>No stats yet — play a game!</p>
+            ) : (
+              <>
+                <div className="leaderboard-row" style={{ justifyContent: 'space-between', padding: '0.5rem 0' }}>
+                  <span>Unique words ever made</span>
+                  <strong>{stats.vocabularySize}</strong>
+                </div>
+                {stats.worldFirsts.length > 0 && (
+                  <div style={{ margin: '0.75rem 0' }}>
+                    <p className="mode-selection-subtitle" style={{ fontSize: '0.85em', marginBottom: '0.25rem' }}>World firsts 🌍</p>
+                    <p style={{ textAlign: 'center', wordBreak: 'break-word' }}>{stats.worldFirsts.join(', ')}</p>
+                  </div>
+                )}
+                {stats.topWords.length > 0 && (
+                  <div style={{ margin: '0.75rem 0' }}>
+                    <p className="mode-selection-subtitle" style={{ fontSize: '0.85em', marginBottom: '0.25rem' }}>Most made</p>
+                    <div className="leaderboard-list">
+                      {stats.topWords.map(({ word, timesMade }) => (
+                        <div key={word} className="leaderboard-row">
+                          <span className="leaderboard-user">{word}</span>
+                          <span className="leaderboard-score">×{timesMade}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </>
+            )}
+            <div className="mode-selection-buttons" style={{ marginTop: '1rem' }}>
+              <button className="mode-selection-btn settings-btn-item" onClick={() => setPanel(null)}>
                 ← Back
               </button>
             </div>

--- a/src/components/Controls/SettingsMenu.jsx
+++ b/src/components/Controls/SettingsMenu.jsx
@@ -78,7 +78,7 @@ function SettingsMenu({ visible, onClose, isMuted, onToggleMute, onPlayReplay })
         >
           ✕
         </button>
-        <h2 className="mode-selection-title">Settings</h2>
+        <h2 className="mode-selection-title">{panel === 'stats' ? 'Stats' : 'Settings'}</h2>
 
         {panel === null && (
           <div className="mode-selection-section">
@@ -149,25 +149,38 @@ function SettingsMenu({ visible, onClose, isMuted, onToggleMute, onPlayReplay })
             ) : (
               <>
                 <div className="leaderboard-row" style={{ justifyContent: 'space-between', padding: '0.5rem 0' }}>
-                  <span>Unique words ever made</span>
+                  <span>Vocabulary</span>
                   <strong>{stats.vocabularySize}</strong>
                 </div>
                 {stats.worldFirsts.length > 0 && (
                   <div style={{ margin: '0.75rem 0' }}>
                     <p className="mode-selection-subtitle" style={{ fontSize: '0.85em', marginBottom: '0.25rem' }}>World firsts 🌍</p>
-                    <p style={{ textAlign: 'center', wordBreak: 'break-word' }}>{stats.worldFirsts.join(', ')}</p>
+                    <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+                      {stats.worldFirsts.map(word => (
+                        <li key={word} className="leaderboard-row" style={{ justifyContent: 'center' }}>{word}</li>
+                      ))}
+                    </ul>
                   </div>
                 )}
                 {stats.topWords.length > 0 && (
                   <div style={{ margin: '0.75rem 0' }}>
-                    <p className="mode-selection-subtitle" style={{ fontSize: '0.85em', marginBottom: '0.25rem' }}>Most made</p>
-                    <div className="leaderboard-list">
-                      {stats.topWords.map(({ word, timesMade }) => (
-                        <div key={word} className="leaderboard-row">
-                          <span className="leaderboard-user">{word}</span>
-                          <span className="leaderboard-score">×{timesMade}</span>
-                        </div>
-                      ))}
+                    <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.5rem' }}>
+                      <div>
+                        <p className="mode-selection-subtitle" style={{ fontSize: '0.8em', marginBottom: '0.25rem' }}>Most made</p>
+                        {stats.topWords.map(({ word, timesMade }) => (
+                          <div key={word} className="leaderboard-row" style={{ justifyContent: 'space-between' }}>
+                            <span>{word}</span><span>×{timesMade}</span>
+                          </div>
+                        ))}
+                      </div>
+                      <div>
+                        <p className="mode-selection-subtitle" style={{ fontSize: '0.8em', marginBottom: '0.25rem' }}>Least made</p>
+                        {stats.rareWords.map(({ word, timesMade }) => (
+                          <div key={word} className="leaderboard-row" style={{ justifyContent: 'space-between' }}>
+                            <span>{word}</span><span>×{timesMade}</span>
+                          </div>
+                        ))}
+                      </div>
                     </div>
                   </div>
                 )}

--- a/src/components/Overlays/GameOverOverlay.jsx
+++ b/src/components/Overlays/GameOverOverlay.jsx
@@ -1,16 +1,31 @@
 import React from 'react';
 
-/**
- * Game over overlay - shows win/loss message and restart button
- *
- * TODO: Enhance this overlay with:
- * - Distinct win vs loss messaging for Clear mode
- * - Animations on appearance (confetti for wins, etc.)
- * - Stats display (tiles cleared, words found, etc.)
- * - Leaderboard or high score tracking
- * - Share score functionality
- */
-function GameOverOverlay({ visible, gameMode, score, lettersRemaining = 0, boardCleared = false, onRestart }) {
+function WordStatsPanel({ wordStats }) {
+  if (!wordStats) return <div className="word-stats-loading">Loading stats…</div>;
+
+  const { vocabularySize, rarestWord, worldFirsts } = wordStats;
+  const showRarity = rarestWord && rarestWord.timesThisUser <= 3;
+
+  return (
+    <div className="word-stats-panel">
+      <div className="word-stat">
+        You&apos;ve now made <strong>{vocabularySize}</strong> unique {vocabularySize === 1 ? 'word' : 'words'} total.
+      </div>
+      {showRarity && (
+        <div className="word-stat">
+          <strong>{rarestWord.word}</strong> — only your {rarestWord.timesThisUser === 1 ? '1st' : rarestWord.timesThisUser === 2 ? '2nd' : '3rd'} time making it!
+        </div>
+      )}
+      {worldFirsts.length > 0 && (
+        <div className="word-stat">
+          World {worldFirsts.length === 1 ? 'first' : 'firsts'}: <strong>{worldFirsts.join(', ')}</strong> — no one else has ever made {worldFirsts.length === 1 ? 'it' : 'these'}!
+        </div>
+      )}
+    </div>
+  );
+}
+
+function GameOverOverlay({ visible, gameMode, score, lettersRemaining = 0, boardCleared = false, wordStats, onRestart }) {
   if (!visible) return null;
 
   const isClearMode = gameMode === 'clear';
@@ -41,6 +56,7 @@ function GameOverOverlay({ visible, gameMode, score, lettersRemaining = 0, board
             Final Score: {finalScore}
           </div>
         )}
+        {wordStats !== undefined && <WordStatsPanel wordStats={wordStats} />}
         <button className="game-over-restart-btn" onClick={onRestart}>
           Play Again
         </button>

--- a/src/context/GameContext.jsx
+++ b/src/context/GameContext.jsx
@@ -109,8 +109,13 @@ export function GameProvider({ children }) {
       fetch('/api/scores', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ score: state.score, gameMode: state.gameMode, username, sessionData }),
-      }).catch(() => {}); // fire-and-forget; don't break the game on DB errors
+        body: JSON.stringify({ score: state.score, gameMode: state.gameMode, username, sessionData, wordsCleared: state.allWordsThisGame }),
+      })
+        .then(r => r.json())
+        .then(data => {
+          if (data.wordStats) dispatch({ type: 'SET_WORD_STATS', payload: data.wordStats });
+        })
+        .catch(() => {}); // don't break the game on DB errors
       sessionStorage.clear(); // game complete — nothing left to resume
     }
   }, [state.status]);

--- a/src/context/GameReducer.js
+++ b/src/context/GameReducer.js
@@ -9,6 +9,8 @@ export const initialState = {
   nextQueue: [], // Array of upcoming letter objects
   status: 'IDLE', // IDLE, PLAYING, GAME_OVER, PROCESSING
   madeWords: [],
+  allWordsThisGame: [], // deduped list of all words cleared this game, for server submission
+  wordStats: null, // populated after game-over score submission
   gameMode: null, // null, 'classic', or 'clear'
   initialBlocks: [] // Array of indices for Clear mode initial blocks
 };
@@ -27,6 +29,8 @@ export function gameReducer(state, action) {
         grid: initialGrid || Array(GRID_SIZE).fill(null),
         score: 0,
         madeWords: [],
+        allWordsThisGame: [],
+        wordStats: null,
         gameMode: mode,
         initialBlocks: initialBlocks || []
       };
@@ -138,6 +142,7 @@ export function gameReducer(state, action) {
       const newGrid = [...state.grid];
       let totalScore = 0;
       const newMadeWords = [...state.madeWords];
+      const wordsSet = new Set(state.allWordsThisGame);
 
       wordsToRemove.forEach(({ word, indices }) => {
         let wordScore;
@@ -152,6 +157,7 @@ export function gameReducer(state, action) {
           totalScore += wordScore;
         }
         newMadeWords.unshift({ word, score: wordScore, chainId, comboDepth });
+        wordsSet.add(word);
         indices.forEach(index => {
           newGrid[index] = null;
         });
@@ -162,9 +168,13 @@ export function gameReducer(state, action) {
         grid: newGrid,
         score: state.gameMode === 'clear' ? totalScore : state.score + totalScore,
         madeWords: newMadeWords.slice(0, 20),
+        allWordsThisGame: Array.from(wordsSet),
         status: 'PLAYING'
       };
     }
+
+    case 'SET_WORD_STATS':
+      return { ...state, wordStats: action.payload };
 
     case 'APPLY_GRAVITY': {
       const newGrid = Array(GRID_SIZE).fill(null);

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -400,6 +400,8 @@ body {
     text-align: center;
     min-width: 300px;
     max-width: 90vw;
+    max-height: min(520px, 85vh);
+    overflow-y: auto;
 }
 
 .mode-selection-close {

--- a/src/styles/grid.css
+++ b/src/styles/grid.css
@@ -476,10 +476,9 @@
     width: 100%;
 }
 
-/* Settings menu uses orange border and light orange background */
-.game-grid-wrapper .mode-selection-menu.settings-variant {
-    background: #FFECC8;   /* light orange indicates SETTINGS mode (orange) */
-    border-color: var(--color-accent-secondary);   /* #FF9800 orange */
+/* Settings menu: dark backdrop (same as replay overlay), orange accent on the card only */
+.mode-selection-menu.settings-variant .mode-selection-content {
+    border-top: 4px solid var(--color-accent-secondary);
 }
 
 /* Leaderboard panel */


### PR DESCRIPTION
## Summary
- Adds `word_history` table tracking every unique word each user has ever made
- Word stats surfaced at game-over (vocabulary size, rarity callout, world firsts) and in a dedicated Stats panel in the settings menu
- Stats panel: dynamic "Stats" header, "Vocabulary" label, world firsts as list, most/least-made side-by-side grid
- Settings menu UI polish: portal moved to `document.body` so panels never clip, dark backdrop replaces orange full-screen background, orange accent moved to card top border
- Dev workflow: `npm run dev` now auto-restarts Express on `server.js` changes via `node --watch`
- Git workflow convention documented in `CLAUDE.md`

## Test plan
- [x] Play a game, verify `word_history` populated in DB
- [x] Game-over overlay shows word stats (vocabulary size, rarity, world firsts)
- [x] Settings → Stats panel shows all sections; header says "Stats"
- [x] Settings panels scroll on short viewports without clipping
- [x] Settings backdrop is dark, not orange
- [x] `npm test` passes (74 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)