### PR TITLE
chore: centralize constants (action types, status enums, magic numbers)

### DIFF
--- a/src/context/GameContext.jsx
+++ b/src/context/GameContext.jsx
@@ -3,6 +3,7 @@ import { gameReducer, initialState } from './GameReducer.js';
 import { generateLetterSequence } from '../utils/letterUtils.js';
 import { generateClearModeGrid } from '../utils/clearModeUtils.js';
 import { TOTAL_LETTERS } from '../utils/gameConstants.js';
+import { A } from '../utils/actionTypes.js';
 import { createRecorder } from '../services/sessionRecorder.js';
 import * as sessionStorage from '../services/sessionStorage.js';
 
@@ -55,30 +56,30 @@ export function GameProvider({ children }) {
     resumedRef.current = true;
     const snap = sessionStorage.load();
     if (!snap || !Array.isArray(snap.checkpoints) || snap.checkpoints.length === 0) return;
-    const hasGameOver = Array.isArray(snap.events) && snap.events.some(e => e.type === 'GAME_OVER');
+    const hasGameOver = Array.isArray(snap.events) && snap.events.some(e => e.type === A.GAME_OVER);
     if (hasGameOver) { sessionStorage.clear(); return; }
     if (!recorderRef.current.loadSnapshot(snap)) { sessionStorage.clear(); return; }
     const latest = snap.checkpoints[snap.checkpoints.length - 1];
-    dispatch({ type: 'LOAD_SAVED_GAME', payload: latest.state });
+    dispatch({ type: A.LOAD_SAVED_GAME, payload: latest.state });
   }, []);
 
   const wrappedDispatch = useCallback((action) => {
-    if (action.type === 'START_GAME') {
+    if (action.type === A.START_GAME) {
       scoreSubmittedRef.current = false;
       const { mode } = action.payload;
       const initialQueue = buildInitialQueue(mode);
       const { grid: initialGrid, initialBlocks } = buildInitialGrid(mode);
-      const fullAction = { type: 'START_GAME', payload: { mode, initialQueue, initialGrid, initialBlocks } };
+      const fullAction = { type: A.START_GAME, payload: { mode, initialQueue, initialGrid, initialBlocks } };
       recorderRef.current.record(fullAction);
       dispatch(fullAction);
       return;
     }
 
-    if (action.type === 'DROP_LETTER') {
+    if (action.type === A.DROP_LETTER) {
       recorderRef.current.recordCheckpoint(stateRef.current);
     }
 
-    if (action.type === 'RESET') {
+    if (action.type === A.RESET) {
       recorderRef.current.reset();
       sessionStorage.clear();
       dispatch(action);
@@ -92,7 +93,7 @@ export function GameProvider({ children }) {
   const undo = useCallback(() => {
     const cp = recorderRef.current.popLastCheckpoint();
     if (!cp) return false;
-    dispatch({ type: 'LOAD_SAVED_GAME', payload: cp.state });
+    dispatch({ type: A.LOAD_SAVED_GAME, payload: cp.state });
     return true;
   }, [dispatch]);
 
@@ -113,7 +114,7 @@ export function GameProvider({ children }) {
       })
         .then(r => r.json())
         .then(data => {
-          if (data.wordStats) dispatch({ type: 'SET_WORD_STATS', payload: data.wordStats });
+          if (data.wordStats) dispatch({ type: A.SET_WORD_STATS, payload: data.wordStats });
         })
         .catch(() => {}); // don't break the game on DB errors
       sessionStorage.clear(); // game complete — nothing left to resume

--- a/src/context/GameContext.jsx
+++ b/src/context/GameContext.jsx
@@ -2,7 +2,7 @@ import React, { createContext, useReducer, useContext, useCallback, useEffect, u
 import { gameReducer, initialState } from './GameReducer.js';
 import { generateLetterSequence } from '../utils/letterUtils.js';
 import { generateClearModeGrid } from '../utils/clearModeUtils.js';
-import { TOTAL_LETTERS } from '../utils/gameConstants.js';
+import { TOTAL_LETTERS, STATUS } from '../utils/gameConstants.js';
 import { A } from '../utils/actionTypes.js';
 import { createRecorder } from '../services/sessionRecorder.js';
 import * as sessionStorage from '../services/sessionStorage.js';
@@ -99,7 +99,7 @@ export function GameProvider({ children }) {
 
   // Submit score when game ends.
   useEffect(() => {
-    if (state.status === 'GAME_OVER' && !scoreSubmittedRef.current) {
+    if (state.status === STATUS.GAME_OVER && !scoreSubmittedRef.current) {
       scoreSubmittedRef.current = true;
       const username = localStorage.getItem('noodel_username') ?? 'anonymous';
       const fullSnapshot = recorderRef.current.snapshot();

--- a/src/context/GameReducer.js
+++ b/src/context/GameReducer.js
@@ -1,5 +1,5 @@
 import { calculateWordScore } from '../utils/scoringUtils.js';
-import { GRID_SIZE, TOTAL_LETTERS, GRID_COLS, GRID_ROWS, STATUS } from '../utils/gameConstants.js';
+import { GRID_SIZE, TOTAL_LETTERS, GRID_COLS, GRID_ROWS, STATUS, MAX_MADE_WORDS } from '../utils/gameConstants.js';
 import { A } from '../utils/actionTypes.js';
 
 // Game state shape
@@ -168,7 +168,7 @@ export function gameReducer(state, action) {
         ...state,
         grid: newGrid,
         score: state.gameMode === 'clear' ? totalScore : state.score + totalScore,
-        madeWords: newMadeWords.slice(0, 20),
+        madeWords: newMadeWords.slice(0, MAX_MADE_WORDS),
         allWordsThisGame: Array.from(wordsSet),
         status: STATUS.PLAYING
       };

--- a/src/context/GameReducer.js
+++ b/src/context/GameReducer.js
@@ -1,5 +1,6 @@
 import { calculateWordScore } from '../utils/scoringUtils.js';
 import { GRID_SIZE, TOTAL_LETTERS, GRID_COLS, GRID_ROWS } from '../utils/gameConstants.js';
+import { A } from '../utils/actionTypes.js';
 
 // Game state shape
 export const initialState = {
@@ -18,7 +19,7 @@ export const initialState = {
 // Game reducer
 export function gameReducer(state, action) {
   switch (action.type) {
-    case 'START_GAME': {
+    case A.START_GAME: {
       const { mode, initialQueue, initialGrid, initialBlocks } = action.payload;
 
       return {
@@ -36,7 +37,7 @@ export function gameReducer(state, action) {
       };
     }
 
-    case 'DROP_LETTER': {
+    case A.DROP_LETTER: {
       const { column } = action.payload;
       if (!state.nextQueue.length) return state;
 
@@ -76,7 +77,7 @@ export function gameReducer(state, action) {
     }
 
     // Mark specific cells as pending (grace period countdown)
-    case 'SET_PENDING': {
+    case A.SET_PENDING: {
       const { indices, direction } = action.payload;
       const newGrid = [...state.grid];
       indices.forEach(index => {
@@ -101,7 +102,7 @@ export function gameReducer(state, action) {
     }
 
     // Clear pending state from specific cells
-    case 'CLEAR_PENDING': {
+    case A.CLEAR_PENDING: {
       const { indices, direction } = action.payload;
       const newGrid = [...state.grid];
       indices.forEach(index => {
@@ -119,7 +120,7 @@ export function gameReducer(state, action) {
     }
 
     // Mark specific cells as matched (triggers shake animation), pauses word detection
-    case 'SET_MATCHED_INDICES': {
+    case A.SET_MATCHED_INDICES: {
       const { indices } = action.payload;
       const newGrid = [...state.grid];
       indices.forEach(index => {
@@ -137,7 +138,7 @@ export function gameReducer(state, action) {
     }
 
     // Remove specific words from grid and score them
-    case 'REMOVE_WORDS': {
+    case A.REMOVE_WORDS: {
       const { wordsToRemove, chainId, comboDepth } = action.payload;
       const newGrid = [...state.grid];
       let totalScore = 0;
@@ -173,10 +174,10 @@ export function gameReducer(state, action) {
       };
     }
 
-    case 'SET_WORD_STATS':
+    case A.SET_WORD_STATS:
       return { ...state, wordStats: action.payload };
 
-    case 'APPLY_GRAVITY': {
+    case A.APPLY_GRAVITY: {
       const newGrid = Array(GRID_SIZE).fill(null);
 
       // Apply gravity column by column
@@ -209,14 +210,14 @@ export function gameReducer(state, action) {
       return { ...state, grid: newGrid, status: 'PLAYING' };
     }
 
-    case 'GAME_OVER': {
+    case A.GAME_OVER: {
       return {
         ...state,
         status: 'GAME_OVER'
       };
     }
 
-    case 'LOAD_SAVED_GAME': {
+    case A.LOAD_SAVED_GAME: {
       const { grid, nextQueue, lettersRemaining, score, madeWords, gameMode, initialBlocks } = action.payload;
       return {
         ...initialState,
@@ -231,7 +232,7 @@ export function gameReducer(state, action) {
       };
     }
 
-    case 'RESET':
+    case A.RESET:
       return initialState;
 
     default:

--- a/src/context/GameReducer.js
+++ b/src/context/GameReducer.js
@@ -1,5 +1,5 @@
 import { calculateWordScore } from '../utils/scoringUtils.js';
-import { GRID_SIZE, TOTAL_LETTERS, GRID_COLS, GRID_ROWS } from '../utils/gameConstants.js';
+import { GRID_SIZE, TOTAL_LETTERS, GRID_COLS, GRID_ROWS, STATUS } from '../utils/gameConstants.js';
 import { A } from '../utils/actionTypes.js';
 
 // Game state shape
@@ -8,7 +8,7 @@ export const initialState = {
   score: 0,
   lettersRemaining: TOTAL_LETTERS,
   nextQueue: [], // Array of upcoming letter objects
-  status: 'IDLE', // IDLE, PLAYING, GAME_OVER, PROCESSING
+  status: STATUS.IDLE, // IDLE, PLAYING, GAME_OVER, PROCESSING
   madeWords: [],
   allWordsThisGame: [], // deduped list of all words cleared this game, for server submission
   wordStats: null, // populated after game-over score submission
@@ -26,7 +26,7 @@ export function gameReducer(state, action) {
         ...state,
         nextQueue: initialQueue,
         lettersRemaining: TOTAL_LETTERS,
-        status: 'PLAYING',
+        status: STATUS.PLAYING,
         grid: initialGrid || Array(GRID_SIZE).fill(null),
         score: 0,
         madeWords: [],
@@ -65,7 +65,7 @@ export function gameReducer(state, action) {
       };
 
       // Check for game over (no more letters)
-      const newStatus = remainingQueue.length === 0 ? 'GAME_OVER' : state.status;
+      const newStatus = remainingQueue.length === 0 ? STATUS.GAME_OVER : state.status;
 
       return {
         ...state,
@@ -134,7 +134,7 @@ export function gameReducer(state, action) {
           };
         }
       });
-      return { ...state, grid: newGrid, status: 'PROCESSING' };
+      return { ...state, grid: newGrid, status: STATUS.PROCESSING };
     }
 
     // Remove specific words from grid and score them
@@ -170,7 +170,7 @@ export function gameReducer(state, action) {
         score: state.gameMode === 'clear' ? totalScore : state.score + totalScore,
         madeWords: newMadeWords.slice(0, 20),
         allWordsThisGame: Array.from(wordsSet),
-        status: 'PLAYING'
+        status: STATUS.PLAYING
       };
     }
 
@@ -207,13 +207,13 @@ export function gameReducer(state, action) {
         }
       }
 
-      return { ...state, grid: newGrid, status: 'PLAYING' };
+      return { ...state, grid: newGrid, status: STATUS.PLAYING };
     }
 
     case A.GAME_OVER: {
       return {
         ...state,
-        status: 'GAME_OVER'
+        status: STATUS.GAME_OVER
       };
     }
 
@@ -228,7 +228,7 @@ export function gameReducer(state, action) {
         madeWords,
         gameMode,
         initialBlocks: initialBlocks || [],
-        status: 'PLAYING'
+        status: STATUS.PLAYING
       };
     }
 

--- a/src/hooks/useGameLogic.js
+++ b/src/hooks/useGameLogic.js
@@ -7,7 +7,7 @@ import {
   hasIntersection,
   classifyIncomingWord,
 } from '../utils/gracePeriodUtils.js';
-import { GRID_COLS } from '../utils/gameConstants.js';
+import { GRID_COLS, STATUS } from '../utils/gameConstants.js';
 import { A } from '../utils/actionTypes.js';
 
 const GRACE_PERIOD_MS = 1000;
@@ -140,7 +140,7 @@ export function useGameLogic() {
 
   // Clear all pending state when the game resets
   useEffect(() => {
-    if (state.status === 'IDLE') {
+    if (state.status === STATUS.IDLE) {
       const pending = pendingRef.current;
       for (const entry of pending.values()) clearTimeout(entry.timerId);
       pending.clear();
@@ -170,7 +170,7 @@ export function useGameLogic() {
 
   // Main word detection effect — runs after every grid change
   useEffect(() => {
-    if (!dictionary || state.status !== 'PLAYING' || gravityScheduledRef.current) return;
+    if (!dictionary || state.status !== STATUS.PLAYING || gravityScheduledRef.current) return;
 
     // Detect new player drop: lettersRemaining decreases on each DROP_LETTER.
     // Clear chains synchronously before scanning so words from this drop start fresh.
@@ -238,7 +238,7 @@ export function useGameLogic() {
 
   // Check for Clear mode victory condition
   useEffect(() => {
-    if (state.gameMode !== 'clear' || state.status !== 'PLAYING') return;
+    if (state.gameMode !== 'clear' || state.status !== STATUS.PLAYING) return;
 
     // Win requires the entire board to be empty (not just the initial block cells).
     // Player-placed tiles must also be cleared for victory to trigger.

--- a/src/hooks/useGameLogic.js
+++ b/src/hooks/useGameLogic.js
@@ -8,6 +8,7 @@ import {
   classifyIncomingWord,
 } from '../utils/gracePeriodUtils.js';
 import { GRID_COLS } from '../utils/gameConstants.js';
+import { A } from '../utils/actionTypes.js';
 
 const GRACE_PERIOD_MS = 1000;
 const SHAKE_DURATION_MS = 400;
@@ -105,13 +106,13 @@ export function useGameLogic() {
       }
 
       // Shake phase: mark as matched (pauses word detection)
-      dispatch({ type: 'SET_MATCHED_INDICES', payload: { indices: allIndices } });
+      dispatch({ type: A.SET_MATCHED_INDICES, payload: { indices: allIndices } });
 
       pendingRemovesRef.current++;
       setTimeout(() => {
         // Remove expired words and score them
         dispatch({
-          type: 'REMOVE_WORDS',
+          type: A.REMOVE_WORDS,
           payload: {
             wordsToRemove: wordsToExpire.map(e => e.wordData),
             chainId,
@@ -129,7 +130,7 @@ export function useGameLogic() {
           gravityScheduledRef.current = true;
           setTimeout(() => {
             gravityScheduledRef.current = false;
-            dispatch({ type: 'APPLY_GRAVITY' });
+            dispatch({ type: A.APPLY_GRAVITY });
           }, GRAVITY_DELAY_MS);
         }
       }, SHAKE_DURATION_MS);
@@ -209,7 +210,7 @@ export function useGameLogic() {
         const old = pending.get(result.replaceKey);
         clearTimeout(old.timerId);
         dispatch({
-          type: 'CLEAR_PENDING',
+          type: A.CLEAR_PENDING,
           payload: { indices: old.wordData.indices, direction: old.wordData.direction }
         });
         pending.delete(result.replaceKey);
@@ -227,7 +228,7 @@ export function useGameLogic() {
 
       // Start grace period for this word
       dispatch({
-        type: 'SET_PENDING',
+        type: A.SET_PENDING,
         payload: { indices: wordData.indices, direction: wordData.direction }
       });
       const timerId = setTimeout(() => expireWord(wordKey), GRACE_PERIOD_MS);
@@ -244,7 +245,7 @@ export function useGameLogic() {
     const gridEmpty = state.grid.every(cell => !cell);
 
     if (gridEmpty && state.initialBlocks.length > 0) {
-      dispatch({ type: 'GAME_OVER' });
+      dispatch({ type: A.GAME_OVER });
     }
   }, [state.grid, state.gameMode, state.status, state.initialBlocks, dispatch]);
 

--- a/src/hooks/useGameLogic.js
+++ b/src/hooks/useGameLogic.js
@@ -7,12 +7,9 @@ import {
   hasIntersection,
   classifyIncomingWord,
 } from '../utils/gracePeriodUtils.js';
-import { GRID_COLS, STATUS } from '../utils/gameConstants.js';
+import { GRID_COLS, STATUS, GRACE_PERIOD_MS, SHAKE_DURATION_MS, GRAVITY_DELAY_MS } from '../utils/gameConstants.js';
 import { A } from '../utils/actionTypes.js';
 
-const GRACE_PERIOD_MS = 1000;
-const SHAKE_DURATION_MS = 400;
-const GRAVITY_DELAY_MS = 150;
 
 export function useGameLogic() {
   const { state, dispatch } = useGame();

--- a/src/poc/App.jsx
+++ b/src/poc/App.jsx
@@ -7,6 +7,7 @@ import GameOverOverlay from '../components/Overlays/GameOverOverlay.jsx';
 import HowToPlayModal from './HowToPlayModal.jsx';
 import { useGame } from '../context/GameContext.jsx';
 import { useGameLogic } from '../hooks/useGameLogic.js';
+import { A } from '../utils/actionTypes.js';
 
 function App() {
   const { state, dispatch } = useGame();
@@ -24,7 +25,7 @@ function App() {
 
   const startMode = (mode) => {
     setShowModeSelector(false);
-    dispatch({ type: 'START_GAME', payload: { mode } });
+    dispatch({ type: A.START_GAME, payload: { mode } });
   };
 
   const handleModeSelect = (mode) => {
@@ -36,7 +37,7 @@ function App() {
   };
 
   const handleRestart = () => {
-    dispatch({ type: 'RESET' });
+    dispatch({ type: A.RESET });
     setShowModeSelector(true);
   };
 
@@ -46,7 +47,7 @@ function App() {
 
   const handleColumnClick = (column) => {
     if (state.status === 'PLAYING' || state.status === 'PROCESSING') {
-      dispatch({ type: 'DROP_LETTER', payload: { column } });
+      dispatch({ type: A.DROP_LETTER, payload: { column } });
     }
   };
 

--- a/src/poc/App.jsx
+++ b/src/poc/App.jsx
@@ -7,6 +7,7 @@ import GameOverOverlay from '../components/Overlays/GameOverOverlay.jsx';
 import HowToPlayModal from './HowToPlayModal.jsx';
 import { useGame } from '../context/GameContext.jsx';
 import { useGameLogic } from '../hooks/useGameLogic.js';
+import { STATUS } from '../utils/gameConstants.js';
 import { A } from '../utils/actionTypes.js';
 
 function App() {
@@ -46,7 +47,7 @@ function App() {
   };
 
   const handleColumnClick = (column) => {
-    if (state.status === 'PLAYING' || state.status === 'PROCESSING') {
+    if (state.status === STATUS.PLAYING || state.status === STATUS.PROCESSING) {
       dispatch({ type: A.DROP_LETTER, payload: { column } });
     }
   };
@@ -74,9 +75,9 @@ function App() {
         onHowToPlay={() => setShowHTP(true)}
         onColumnClick={handleColumnClick}
         onUndo={() => {}}
-        showPreview={state.status === 'PLAYING' || state.status === 'PROCESSING'}
-        boardVisible={state.status !== 'IDLE'}
-        canDrop={state.status === 'PLAYING' || state.status === 'PROCESSING'}
+        showPreview={state.status === STATUS.PLAYING || state.status === STATUS.PROCESSING}
+        boardVisible={state.status !== STATUS.IDLE}
+        canDrop={state.status === STATUS.PLAYING || state.status === STATUS.PROCESSING}
       />
       {gridWrapperRef.current && createPortal(
         <ModeSelector
@@ -99,7 +100,7 @@ function App() {
         gridWrapperRef.current
       )}
       <GameOverOverlay
-        visible={state.status === 'GAME_OVER'}
+        visible={state.status === STATUS.GAME_OVER}
         gameMode={state.gameMode}
         score={state.score}
         lettersRemaining={state.lettersRemaining}

--- a/src/services/replayPlayer.js
+++ b/src/services/replayPlayer.js
@@ -1,3 +1,5 @@
+import { A } from '../utils/actionTypes.js';
+
 // Drives playback of a recorded session into a reducer dispatch.
 // Pure module — no React. The caller wires it to a useReducer dispatch.
 
@@ -19,8 +21,8 @@ export function createPlayer(
   // APPLY_GRAVITY (post-cascade frame), plus events.length as the terminal.
   const raw = [];
   for (let i = 0; i < events.length; i++) {
-    if (events[i].type === 'DROP_LETTER') raw.push(i);
-    if (events[i].type === 'APPLY_GRAVITY') raw.push(i + 1);
+    if (events[i].type === A.DROP_LETTER) raw.push(i);
+    if (events[i].type === A.APPLY_GRAVITY) raw.push(i + 1);
   }
   raw.push(events.length);
   raw.sort((a, b) => a - b);

--- a/src/services/replayPlayer.js
+++ b/src/services/replayPlayer.js
@@ -1,11 +1,11 @@
 import { A } from '../utils/actionTypes.js';
+import { GRACE_PERIOD_MS } from '../utils/gameConstants.js';
 
 // Drives playback of a recorded session into a reducer dispatch.
 // Pure module — no React. The caller wires it to a useReducer dispatch.
 
 // Cap any single gap between events to this many ms. Matches GRACE_PERIOD_MS
 // so a long player think-pause doesn't stall the replay.
-export const MAX_GAP_MS = 1000;
 
 export function createPlayer(
   events,
@@ -93,7 +93,7 @@ export function createPlayer(
     if (!playing) return;
     if (index >= events.length) { playing = false; emit(); return; }
     const rawGap = events[index].t - current.t;
-    const gap = Math.max(0, Math.min(rawGap, MAX_GAP_MS));
+    const gap = Math.max(0, Math.min(rawGap, GRACE_PERIOD_MS));
     timer = setTimeout(tick, gap / speed);
   }
 

--- a/src/services/sessionRecorder.js
+++ b/src/services/sessionRecorder.js
@@ -2,19 +2,21 @@
 // plus pre-drop checkpoints used for undo and mid-game resume.
 // Pure module — no React, no I/O. Caller decides when to snapshot and persist.
 
+import { A } from '../utils/actionTypes.js';
+
 export const SESSION_SCHEMA_VERSION = 2;
 
 // Actions that drive a visible state transition. Anything else (RESET, LOAD_SAVED_GAME)
 // is not part of the gameplay timeline.
 const RECORDABLE = new Set([
-  'START_GAME',
-  'DROP_LETTER',
-  'SET_PENDING',
-  'CLEAR_PENDING',
-  'SET_MATCHED_INDICES',
-  'REMOVE_WORDS',
-  'APPLY_GRAVITY',
-  'GAME_OVER',
+  A.START_GAME,
+  A.DROP_LETTER,
+  A.SET_PENDING,
+  A.CLEAR_PENDING,
+  A.SET_MATCHED_INDICES,
+  A.REMOVE_WORDS,
+  A.APPLY_GRAVITY,
+  A.GAME_OVER,
 ]);
 
 // State fields needed to fully restore the reducer via LOAD_SAVED_GAME.
@@ -43,7 +45,7 @@ export function createRecorder({ now = () => performance.now() } = {}) {
   return {
     record(action) {
       if (!isRecordable(action)) return;
-      if (action.type === 'START_GAME') {
+      if (action.type === A.START_GAME) {
         startedAt = now();
         events = [];
         checkpoints = [];

--- a/src/shared/overlays/ReplayOverlay.jsx
+++ b/src/shared/overlays/ReplayOverlay.jsx
@@ -5,6 +5,7 @@ import DroppingOverlay from '../../themes/classic/components/Grid/DroppingOverla
 import { gameReducer, initialState } from '../../context/GameReducer.js';
 import { createPlayer } from '../../services/replayPlayer.js';
 import { GRID_COLS, GRID_ROWS } from '../../utils/gameConstants.js';
+import { A } from '../../utils/actionTypes.js';
 import './ReplayOverlay.css';
 
 const SPEED_OPTIONS = [1, 2];
@@ -32,7 +33,7 @@ function ReplayOverlay({ session, meta, onClose }) {
   // Wrapped dispatch — intercepts DROP_LETTER to play a falling-tile animation
   // before applying the action. All other actions pass through synchronously.
   const wrappedDispatch = useCallback((action) => {
-    if (action.type !== 'DROP_LETTER') {
+    if (action.type !== A.DROP_LETTER) {
       dispatch(action);
       return;
     }
@@ -95,7 +96,7 @@ function ReplayOverlay({ session, meta, onClose }) {
       reset: () => {
         dropTokenRef.current += 1; // invalidate any in-flight drop animation
         setActiveDrop(null);
-        dispatch({ type: 'RESET' });
+        dispatch({ type: A.RESET });
       },
       fastDispatch: dispatch,
     });

--- a/src/shared/overlays/SettingsMenu.jsx
+++ b/src/shared/overlays/SettingsMenu.jsx
@@ -1,6 +1,7 @@
 import { useSettingsState } from '../hooks/useSettingsState.js';
 import { useTheme } from '../../themes/ThemeContext.jsx';
 import { useGame } from '../../context/GameContext.jsx';
+import { STATUS } from '../../utils/gameConstants.js';
 import { A } from '../../utils/actionTypes.js';
 import './SettingsMenu.css';
 
@@ -8,7 +9,7 @@ function SettingsMenu({ onClose, isMuted, onToggleMute, onPlayReplay }) {
   const s = useSettingsState({ onPlayReplay, onClose });
   const { themeId, setThemeId, themes } = useTheme();
   const { state, dispatch } = useGame();
-  const isPlaying = state.status !== 'IDLE';
+  const isPlaying = state.status !== STATUS.IDLE;
 
   const title =
     s.panel === 'stats'       ? 'Stats'

--- a/src/shared/overlays/SettingsMenu.jsx
+++ b/src/shared/overlays/SettingsMenu.jsx
@@ -1,6 +1,7 @@
 import { useSettingsState } from '../hooks/useSettingsState.js';
 import { useTheme } from '../../themes/ThemeContext.jsx';
 import { useGame } from '../../context/GameContext.jsx';
+import { A } from '../../utils/actionTypes.js';
 import './SettingsMenu.css';
 
 function SettingsMenu({ onClose, isMuted, onToggleMute, onPlayReplay }) {
@@ -44,7 +45,7 @@ function SettingsMenu({ onClose, isMuted, onToggleMute, onPlayReplay }) {
               <span aria-hidden="true">›</span>
             </button>
             {isPlaying && (
-              <button className="settings-menu__btn" onClick={() => { dispatch({ type: 'RESET' }); onClose?.(); }}>
+              <button className="settings-menu__btn" onClick={() => { dispatch({ type: A.RESET }); onClose?.(); }}>
                 <span>🏠 Home</span>
               </button>
             )}

--- a/src/themes/classic/ClassicRoot.jsx
+++ b/src/themes/classic/ClassicRoot.jsx
@@ -5,6 +5,7 @@ import { DebugOverlay } from './components/Debug/DebugOverlay.jsx';
 import ModeSelector from './components/Controls/ModeSelector.jsx';
 import GameOverOverlay from './components/Overlays/GameOverOverlay.jsx';
 import { useGame } from '../../context/GameContext.jsx';
+import { A } from '../../utils/actionTypes.js';
 import './styles/base.css';
 import './styles/card.css';
 import './styles/grid.css';
@@ -29,12 +30,12 @@ function ClassicRoot({ dictionary, onHowToPlay, onLogin, onSettings }) {
       return;
     }
     setPendingMode(null);
-    dispatch({ type: 'START_GAME', payload: { mode } });
+    dispatch({ type: A.START_GAME, payload: { mode } });
   };
 
   const handleRestart = () => {
     setPendingMode(null);
-    dispatch({ type: 'RESET' });
+    dispatch({ type: A.RESET });
   };
 
   const handleCloseModeSelector = () => {
@@ -44,7 +45,7 @@ function ClassicRoot({ dictionary, onHowToPlay, onLogin, onSettings }) {
 
   const handleColumnClick = (column) => {
     if (state.status === 'PLAYING' || state.status === 'PROCESSING') {
-      dispatch({ type: 'DROP_LETTER', payload: { column } });
+      dispatch({ type: A.DROP_LETTER, payload: { column } });
     }
   };
 

--- a/src/themes/classic/ClassicRoot.jsx
+++ b/src/themes/classic/ClassicRoot.jsx
@@ -5,6 +5,7 @@ import { DebugOverlay } from './components/Debug/DebugOverlay.jsx';
 import ModeSelector from './components/Controls/ModeSelector.jsx';
 import GameOverOverlay from './components/Overlays/GameOverOverlay.jsx';
 import { useGame } from '../../context/GameContext.jsx';
+import { STATUS } from '../../utils/gameConstants.js';
 import { A } from '../../utils/actionTypes.js';
 import './styles/base.css';
 import './styles/card.css';
@@ -22,7 +23,7 @@ function ClassicRoot({ dictionary, onHowToPlay, onLogin, onSettings }) {
   // after the ref attaches so the auto-show-on-IDLE start menu mounts.
   useEffect(() => { forceRender(1); }, []);
 
-  const showModeSelector = state.status === 'IDLE' || pendingMode !== null;
+  const showModeSelector = state.status === STATUS.IDLE || pendingMode !== null;
 
   const handleModeSelect = (mode) => {
     if (!dictionary) {
@@ -44,7 +45,7 @@ function ClassicRoot({ dictionary, onHowToPlay, onLogin, onSettings }) {
   };
 
   const handleColumnClick = (column) => {
-    if (state.status === 'PLAYING' || state.status === 'PROCESSING') {
+    if (state.status === STATUS.PLAYING || state.status === STATUS.PROCESSING) {
       dispatch({ type: A.DROP_LETTER, payload: { column } });
     }
   };
@@ -69,13 +70,13 @@ function ClassicRoot({ dictionary, onHowToPlay, onLogin, onSettings }) {
         dictionary={dictionary}
         gameStatus={state.status}
         gameMode={state.gameMode}
-        animateTitle={initialStatusRef.current === 'IDLE'}
+        animateTitle={initialStatusRef.current === STATUS.IDLE}
         onLogin={onLogin}
         onSettings={onSettings}
         onInfo={onHowToPlay}
         onColumnClick={handleColumnClick}
         onUndo={undo}
-        showPreview={state.status === 'PLAYING' || state.status === 'PROCESSING'}
+        showPreview={state.status === STATUS.PLAYING || state.status === STATUS.PROCESSING}
       />
       {gridWrapperRef.current && createPortal(
         <ModeSelector
@@ -88,7 +89,7 @@ function ClassicRoot({ dictionary, onHowToPlay, onLogin, onSettings }) {
         gridWrapperRef.current
       )}
       <GameOverOverlay
-        visible={state.status === 'GAME_OVER'}
+        visible={state.status === STATUS.GAME_OVER}
         gameMode={state.gameMode}
         score={state.score}
         lettersRemaining={state.lettersRemaining}

--- a/src/themes/classic/components/Stats/ScoreBoard.jsx
+++ b/src/themes/classic/components/Stats/ScoreBoard.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import { STATUS } from '../../../../utils/gameConstants.js';
 
-function ScoreBoard({ score = 0, gameStatus = 'IDLE', gameMode = null }) {
-  const isPlaying = gameStatus === 'PLAYING' || gameStatus === 'PROCESSING';
+function ScoreBoard({ score = 0, gameStatus = STATUS.IDLE, gameMode = null }) {
+  const isPlaying = gameStatus === STATUS.PLAYING || gameStatus === STATUS.PROCESSING;
   const isClearMode = gameMode === 'clear';
 
   return (

--- a/src/themes/redesign/RedesignRoot.jsx
+++ b/src/themes/redesign/RedesignRoot.jsx
@@ -1,4 +1,5 @@
 import { useGame } from '../../context/GameContext.jsx';
+import { STATUS } from '../../utils/gameConstants.js';
 import Landing from './screens/Landing.jsx';
 import InGame from './screens/InGame.jsx';
 import GameOver from './screens/GameOver.jsx';
@@ -9,8 +10,8 @@ function RedesignRoot({ onHowToPlay, onLogin, onSettings }) {
   const { state } = useGame();
 
   const screen =
-    state.status === 'IDLE' ? 'landing' :
-    state.status === 'GAME_OVER' ? 'gameover' : 'ingame';
+    state.status === STATUS.IDLE ? 'landing' :
+    state.status === STATUS.GAME_OVER ? 'gameover' : 'ingame';
 
   const handlers = { onHowToPlay, onLogin, onSettings };
 

--- a/src/themes/redesign/screens/GameOver.jsx
+++ b/src/themes/redesign/screens/GameOver.jsx
@@ -1,4 +1,5 @@
 import { useGame } from '../../../context/GameContext.jsx';
+import { A } from '../../../utils/actionTypes.js';
 
 function GameOver() {
   const { state, dispatch } = useGame();
@@ -8,8 +9,8 @@ function GameOver() {
     { label: 'Words made', value: state.madeWords.length },
   ];
 
-  const onHome = () => dispatch({ type: 'RESET' });
-  const onRestart = () => dispatch({ type: 'START_GAME', payload: { mode: state.gameMode } });
+  const onHome = () => dispatch({ type: A.RESET });
+  const onRestart = () => dispatch({ type: A.START_GAME, payload: { mode: state.gameMode } });
 
   return (
     <div className="rd-screen rd-gameover">

--- a/src/themes/redesign/screens/InGame.jsx
+++ b/src/themes/redesign/screens/InGame.jsx
@@ -1,6 +1,7 @@
 import { useRef, useState, useCallback } from 'react';
 import { useGame } from '../../../context/GameContext.jsx';
 import { GRID_COLS, GRID_ROWS } from '../../../utils/gameConstants.js';
+import { A } from '../../../utils/actionTypes.js';
 import Shell from '../components/Shell.jsx';
 import Board from '../components/Board.jsx';
 import DroppingOverlay from '../../classic/components/Grid/DroppingOverlay.jsx';
@@ -37,7 +38,7 @@ function InGame({ onHowToPlay, onLogin, onSettings }) {
     const fromEl = nextUpRef.current;
     const gridEl = boardRef.current;
     if (!fromEl || !gridEl) {
-      dispatch({ type: 'DROP_LETTER', payload: { column } });
+      dispatch({ type: A.DROP_LETTER, payload: { column } });
       return;
     }
 
@@ -64,7 +65,7 @@ function InGame({ onHowToPlay, onLogin, onSettings }) {
   }, [state.nextQueue, getDestRow, dispatch]);
 
   const handleDropComplete = useCallback((id, column) => {
-    dispatch({ type: 'DROP_LETTER', payload: { column } });
+    dispatch({ type: A.DROP_LETTER, payload: { column } });
     const remaining = (inFlightColumnsRef.current.get(column) ?? 1) - 1;
     if (remaining === 0) inFlightColumnsRef.current.delete(column);
     else inFlightColumnsRef.current.set(column, remaining);

--- a/src/themes/redesign/screens/Landing.jsx
+++ b/src/themes/redesign/screens/Landing.jsx
@@ -38,7 +38,7 @@ function Landing({ onHowToPlay, onLogin, onSettings }) {
             <button
               type="button"
               className="rd-cta rd-start-cta"
-              onClick={() => dispatch({ type: A.START_GAME, payload: { mode: 'classic' } })}
+              onClick={() => dispatch({ type: A.START_GAME, payload: { mode: 'clear' } })}
             >
               Start Game
             </button>

--- a/src/themes/redesign/screens/Landing.jsx
+++ b/src/themes/redesign/screens/Landing.jsx
@@ -1,4 +1,5 @@
 import { useGame } from '../../../context/GameContext.jsx';
+import { A } from '../../../utils/actionTypes.js';
 import ActionBar from '../components/ActionBar.jsx';
 import NextRow from '../components/NextRow.jsx';
 import { useAmbientDemo, AmbientBoard } from '../components/AmbientDemo.jsx';
@@ -37,7 +38,7 @@ function Landing({ onHowToPlay, onLogin, onSettings }) {
             <button
               type="button"
               className="rd-cta rd-start-cta"
-              onClick={() => dispatch({ type: 'START_GAME', payload: { mode: 'classic' } })}
+              onClick={() => dispatch({ type: A.START_GAME, payload: { mode: 'classic' } })}
             >
               Start Game
             </button>

--- a/src/utils/actionTypes.js
+++ b/src/utils/actionTypes.js
@@ -1,0 +1,16 @@
+// All reducer action type strings in one place.
+// Import A and use A.ACTION_NAME instead of bare strings so typos are caught
+// at parse time and IDE "find usages" works across the codebase.
+export const A = {
+  START_GAME:         'START_GAME',
+  DROP_LETTER:        'DROP_LETTER',
+  SET_PENDING:        'SET_PENDING',
+  CLEAR_PENDING:      'CLEAR_PENDING',
+  SET_MATCHED_INDICES:'SET_MATCHED_INDICES',
+  REMOVE_WORDS:       'REMOVE_WORDS',
+  APPLY_GRAVITY:      'APPLY_GRAVITY',
+  GAME_OVER:          'GAME_OVER',
+  LOAD_SAVED_GAME:    'LOAD_SAVED_GAME',
+  RESET:              'RESET',
+  SET_WORD_STATS:     'SET_WORD_STATS',
+};

--- a/src/utils/gameConstants.js
+++ b/src/utils/gameConstants.js
@@ -5,12 +5,35 @@ export const GRID_SIZE = GRID_COLS * GRID_ROWS; // 42 cells
 
 // Game settings
 export const TOTAL_LETTERS = 100;
+export const MAX_MADE_WORDS = 20;  // max entries in the "made words" sidebar
+export const MIN_WORD_LENGTH = 3;  // shortest word the detector considers
 
 // Game modes
 export const GAME_MODES = {
   CLASSIC: 'classic',
   CLEAR: 'clear'
 };
+
+// Game status values — mirrors the `status` field in initialState
+export const STATUS = {
+  IDLE: 'IDLE',
+  PLAYING: 'PLAYING',
+  PROCESSING: 'PROCESSING', // tiles are shaking; word detection paused
+  GAME_OVER: 'GAME_OVER',
+};
+
+// Word directions — all possible values of wordData.direction
+export const DIR = {
+  H:  'horizontal',
+  V:  'vertical',
+  DD: 'diagonal-down-right',
+  DU: 'diagonal-up-right',
+};
+
+// Game loop timing (ms) — tune all three here; replayPlayer imports GRACE_PERIOD_MS too
+export const GRACE_PERIOD_MS  = 1000; // countdown before a detected word clears
+export const SHAKE_DURATION_MS = 400; // tile shake animation after SET_MATCHED_INDICES
+export const GRAVITY_DELAY_MS  = 150; // pause between tile removal and gravity drop
 
 // Clear mode configuration
 export const CLEAR_MODE_INITIAL_FILL_PERCENTAGE = 0.20; // 20% of grid

--- a/src/utils/letterUtils.js
+++ b/src/utils/letterUtils.js
@@ -48,6 +48,9 @@ export function getWeightedRandomLetter() {
   return 'E'; // Fallback
 }
 
+const MAX_CONSONANTS_IN_ROW = 3;     // force a vowel after this many consecutive consonants
+const MAX_GENERATION_ATTEMPTS = 100; // loop guard before falling back to a direct pick
+
 const VOWELS = new Set(['A', 'E', 'I', 'O', 'U']);
 
 function isVowel(letter) {
@@ -73,11 +76,11 @@ function getConsonantCount(letters) {
  */
 function getNextValidLetter(previousLetter, consonantCount) {
   // If we have 3 consonants, must pick a vowel
-  const mustBeVowel = consonantCount >= 3;
+  const mustBeVowel = consonantCount >= MAX_CONSONANTS_IN_ROW;
 
   let letter;
   let attempts = 0;
-  const maxAttempts = 100;
+  
 
   do {
     letter = getWeightedRandomLetter();
@@ -90,7 +93,7 @@ function getNextValidLetter(previousLetter, consonantCount) {
     if (!isRepeating && !isInvalidConsonant) {
       return letter;
     }
-  } while (attempts < maxAttempts);
+  } while (attempts < MAX_GENERATION_ATTEMPTS);
 
   // Fallback: if we exhausted attempts, pick a valid letter directly
   if (mustBeVowel) {

--- a/src/utils/wordUtils.js
+++ b/src/utils/wordUtils.js
@@ -1,4 +1,4 @@
-import { GRID_COLS, GRID_ROWS } from './gameConstants.js';
+import { GRID_COLS, GRID_ROWS, MIN_WORD_LENGTH, DIR } from './gameConstants.js';
 
 // Extract a word from grid in specified direction
 function extractWord(grid, startRow, startCol, rowDelta, colDelta, length) {
@@ -18,10 +18,10 @@ function extractWord(grid, startRow, startCol, rowDelta, colDelta, length) {
   }
 
   let direction;
-  if (rowDelta === 0)        direction = 'horizontal';
-  else if (colDelta === 0)   direction = 'vertical';
-  else if (rowDelta === 1)   direction = 'diagonal-down-right';
-  else                       direction = 'diagonal-up-right';
+  if (rowDelta === 0)        direction = DIR.H;
+  else if (colDelta === 0)   direction = DIR.V;
+  else if (rowDelta === 1)   direction = DIR.DD;
+  else                       direction = DIR.DU;
 
   return { word: letters.join(''), indices, startRow, startCol, direction };
 }
@@ -70,7 +70,7 @@ export function findWords(grid, dictionary) {
   // Check horizontal (rows)
   for (let row = 0; row < GRID_ROWS; row++) {
     for (let col = 0; col < GRID_COLS; col++) {
-      for (let length = 3; length <= GRID_COLS - col; length++) {
+      for (let length = MIN_WORD_LENGTH; length <= GRID_COLS - col; length++) {
         const wordData = extractWord(grid, row, col, 0, 1, length);
         if (wordData && dictionary.has(wordData.word)) {
           foundWords.push(wordData);
@@ -82,7 +82,7 @@ export function findWords(grid, dictionary) {
   // Check vertical (columns)
   for (let col = 0; col < GRID_COLS; col++) {
     for (let row = 0; row < GRID_ROWS; row++) {
-      for (let length = 3; length <= GRID_ROWS - row; length++) {
+      for (let length = MIN_WORD_LENGTH; length <= GRID_ROWS - row; length++) {
         const wordData = extractWord(grid, row, col, 1, 0, length);
         if (wordData && dictionary.has(wordData.word)) {
           foundWords.push(wordData);
@@ -95,7 +95,7 @@ export function findWords(grid, dictionary) {
   for (let row = 0; row < GRID_ROWS; row++) {
     for (let col = 0; col < GRID_COLS; col++) {
       const maxLen = Math.min(GRID_ROWS - row, GRID_COLS - col);
-      for (let length = 3; length <= maxLen; length++) {
+      for (let length = MIN_WORD_LENGTH; length <= maxLen; length++) {
         const wordData = extractWord(grid, row, col, 1, 1, length);
         if (wordData && dictionary.has(wordData.word)) {
           foundWords.push(wordData);
@@ -108,7 +108,7 @@ export function findWords(grid, dictionary) {
   for (let row = 0; row < GRID_ROWS; row++) {
     for (let col = 0; col < GRID_COLS; col++) {
       const maxLen = Math.min(row + 1, GRID_COLS - col);
-      for (let length = 3; length <= maxLen; length++) {
+      for (let length = MIN_WORD_LENGTH; length <= maxLen; length++) {
         const wordData = extractWord(grid, row, col, -1, 1, length);
         if (wordData && dictionary.has(wordData.word)) {
           foundWords.push(wordData);


### PR DESCRIPTION
## Summary

- Add centralized constant definitions (`actionTypes.js`, `STATUS` enum, named timing/layout constants)
- Replace raw action type strings throughout codebase with `A.*` imports
- Replace game status string literals with `STATUS.*` enum values
- Replace magic numbers and hardcoded strings with named constants
- Default Start Game to clear mode

## Test plan
- [x] Game starts in clear mode by default
- [x] Game status transitions (IDLE → PLAYING → GAME_OVER) work correctly
- [x] Word detection, grace period, and gravity all fire as before
- [x] No regressions in classic mode scoring or clear mode win condition