### PR TITLE
feat: vocabulary viewer — searchable paginated word browser

### DIFF
--- a/server.js
+++ b/server.js
@@ -115,6 +115,20 @@ app.get('/api/scores/:id/session', async (req, res) => {
   }
 });
 
+app.get('/api/vocabulary', async (req, res) => {
+  try {
+    const username = req.query.username || 'anonymous';
+    const result = await pool.query(
+      'SELECT word, times_made FROM word_history WHERE username = $1 ORDER BY word ASC',
+      [username]
+    );
+    res.json({ words: result.rows.map(r => ({ word: r.word, timesMade: r.times_made })) });
+  } catch (err) {
+    console.error('GET /api/vocabulary error:', err);
+    res.status(500).json({ error: 'internal server error' });
+  }
+});
+
 app.get('/api/user-stats', async (req, res) => {
   try {
     const username = req.query.username || 'anonymous';

--- a/src/shared/hooks/useSettingsState.js
+++ b/src/shared/hooks/useSettingsState.js
@@ -11,6 +11,9 @@ export function useSettingsState({ onPlayReplay, onClose } = {}) {
   const [loadingScores, setLoadingScores] = useState(false);
   const [stats, setStats] = useState(null);
   const [loadingStats, setLoadingStats] = useState(false);
+  const [vocabWords, setVocabWords] = useState([]);
+  const [loadingVocab, setLoadingVocab] = useState(false);
+  const [showVocab, setShowVocab] = useState(false);
 
   function selectUser(name) {
     localStorage.setItem('noodel_username', name);
@@ -45,6 +48,21 @@ export function useSettingsState({ onPlayReplay, onClose } = {}) {
     }
   }
 
+  async function openVocabulary() {
+    setShowVocab(true);
+    setLoadingVocab(true);
+    try {
+      const username = localStorage.getItem('noodel_username') ?? 'anonymous';
+      const res = await fetch(`/api/vocabulary?username=${encodeURIComponent(username)}`);
+      const data = await res.json();
+      setVocabWords(data.words?.map(w => w.word) ?? []);
+    } catch {
+      setVocabWords([]);
+    } finally {
+      setLoadingVocab(false);
+    }
+  }
+
   async function handleReplay(scoreId) {
     try {
       const res = await fetch(`/api/scores/${scoreId}/session`);
@@ -68,5 +86,6 @@ export function useSettingsState({ onPlayReplay, onClose } = {}) {
     stats, loadingStats, openStats,
     scores, loadingScores, openLeaderboard,
     handleReplay,
+    vocabWords, loadingVocab, showVocab, setShowVocab, openVocabulary,
   };
 }

--- a/src/shared/overlays/SettingsMenu.jsx
+++ b/src/shared/overlays/SettingsMenu.jsx
@@ -3,6 +3,7 @@ import { useTheme } from '../../themes/ThemeContext.jsx';
 import { useGame } from '../../context/GameContext.jsx';
 import { STATUS } from '../../utils/gameConstants.js';
 import { A } from '../../utils/actionTypes.js';
+import WordListModal from './WordListModal.jsx';
 import './SettingsMenu.css';
 
 function SettingsMenu({ onClose, isMuted, onToggleMute, onPlayReplay }) {
@@ -16,6 +17,16 @@ function SettingsMenu({ onClose, isMuted, onToggleMute, onPlayReplay }) {
     : s.panel === 'leaderboard' ? 'Leaderboard'
     : s.panel === 'theme'     ? 'Theme'
     : 'Settings';
+
+  if (s.showVocab) {
+    return (
+      <WordListModal
+        words={s.vocabWords}
+        onClose={() => s.setShowVocab(false)}
+        title="My Vocabulary"
+      />
+    );
+  }
 
   return (
     <div className="settings-menu" onClick={onClose}>
@@ -36,6 +47,10 @@ function SettingsMenu({ onClose, isMuted, onToggleMute, onPlayReplay }) {
             </button>
             <button className="settings-menu__btn" onClick={s.openLeaderboard}>
               <span>🏆 Leaderboard</span>
+              <span aria-hidden="true">›</span>
+            </button>
+            <button className="settings-menu__btn" onClick={s.openVocabulary}>
+              <span>📖 Vocabulary</span>
               <span aria-hidden="true">›</span>
             </button>
             <button className="settings-menu__btn" onClick={onToggleMute}>

--- a/src/shared/overlays/WordListModal.css
+++ b/src/shared/overlays/WordListModal.css
@@ -1,0 +1,173 @@
+.wlm-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 24, 39, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1200;
+  padding: 16px;
+  backdrop-filter: blur(2px);
+}
+
+.wlm-card {
+  position: relative;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 16px;
+  box-shadow: 0 12px 32px rgba(17, 24, 39, 0.10);
+  max-width: 480px;
+  width: 100%;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  padding: 24px;
+  font-family: inherit;
+  gap: 12px;
+  overflow: hidden;
+}
+
+.wlm-close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: transparent;
+  border: none;
+  color: #9ca3af;
+  font-size: 16px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s, color 0.15s;
+}
+.wlm-close:hover {
+  background: #f3f4f6;
+  color: #111827;
+}
+
+.wlm-title {
+  font-size: 20px;
+  font-weight: 700;
+  color: #111827;
+  margin: 0;
+  padding-right: 36px;
+  flex-shrink: 0;
+}
+
+.wlm-search-wrap {
+  flex-shrink: 0;
+}
+
+.wlm-search {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  font-size: 14px;
+  font-family: inherit;
+  color: #111827;
+  background: #f9fafb;
+  box-sizing: border-box;
+  outline: none;
+  transition: border-color 0.15s;
+}
+.wlm-search:focus {
+  border-color: #388E3C;
+  background: #fff;
+}
+
+.wlm-list {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 0;
+}
+
+.wlm-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 12px;
+  background: #f9fafb;
+  border-left: 3px solid #388E3C;
+  border-radius: 6px;
+  flex-shrink: 0;
+}
+
+.wlm-item__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.wlm-item__word {
+  font-size: 14px;
+  font-weight: 700;
+  color: #111827;
+  letter-spacing: 0.04em;
+}
+
+.wlm-item__badge {
+  font-size: 10px;
+  font-weight: 700;
+  color: #fff;
+  background: #388E3C;
+  padding: 2px 6px;
+  border-radius: 4px;
+  letter-spacing: 0.05em;
+}
+
+.wlm-item__def {
+  font-size: 12px;
+  color: #6b7280;
+  line-height: 1.4;
+}
+
+.wlm-empty {
+  text-align: center;
+  color: #9ca3af;
+  font-size: 14px;
+  padding: 24px 0;
+  margin: 0;
+}
+
+.wlm-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+  padding-top: 8px;
+  border-top: 1px solid #e5e7eb;
+}
+
+.wlm-nav__btn {
+  padding: 6px 14px;
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #374151;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.15s;
+}
+.wlm-nav__btn:hover:not(:disabled) {
+  background: #e5e7eb;
+}
+.wlm-nav__btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.wlm-nav__label {
+  font-size: 13px;
+  color: #6b7280;
+  font-weight: 500;
+}

--- a/src/shared/overlays/WordListModal.jsx
+++ b/src/shared/overlays/WordListModal.jsx
@@ -1,0 +1,81 @@
+import { useState, useMemo } from 'react';
+import { useDictionary } from '../../hooks/useDictionary.js';
+import './WordListModal.css';
+
+const PAGE_SIZE = 15;
+
+export default function WordListModal({ words, newWords, onClose, title }) {
+  const { dictionary } = useDictionary();
+  const [search, setSearch] = useState('');
+  const [page, setPage] = useState(0);
+
+  const sorted = useMemo(() => [...words].sort(), [words]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toUpperCase();
+    return q ? sorted.filter(w => w.includes(q)) : sorted;
+  }, [sorted, search]);
+
+  const isSearching = search.trim().length > 0;
+  const pageCount = isSearching ? 1 : Math.ceil(filtered.length / PAGE_SIZE);
+  const displayed = isSearching ? filtered : filtered.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
+
+  const handleSearch = (e) => {
+    setSearch(e.target.value);
+    setPage(0);
+  };
+
+  return (
+    <div className="wlm-backdrop" onClick={onClose}>
+      <div className="wlm-card" onClick={e => e.stopPropagation()}>
+        <button type="button" className="wlm-close" onClick={onClose} aria-label="Close">✕</button>
+        <h2 className="wlm-title">{title}</h2>
+
+        <div className="wlm-search-wrap">
+          <input
+            className="wlm-search"
+            type="text"
+            placeholder="Search words…"
+            value={search}
+            onChange={handleSearch}
+            autoFocus
+          />
+        </div>
+
+        {filtered.length === 0 ? (
+          <p className="wlm-empty">{search ? 'No matching words.' : 'No words yet.'}</p>
+        ) : (
+          <div className="wlm-list">
+            {displayed.map(word => (
+              <div key={word} className="wlm-item">
+                <div className="wlm-item__header">
+                  <span className="wlm-item__word">{word}</span>
+                  {newWords?.has(word) && <span className="wlm-item__badge">NEW</span>}
+                </div>
+                {dictionary && (
+                  <span className="wlm-item__def">{dictionary.get(word) || '—'}</span>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {!isSearching && pageCount > 1 && (
+          <div className="wlm-nav">
+            <button
+              className="wlm-nav__btn"
+              onClick={() => setPage(p => p - 1)}
+              disabled={page === 0}
+            >‹ Prev</button>
+            <span className="wlm-nav__label">Page {page + 1} of {pageCount}</span>
+            <button
+              className="wlm-nav__btn"
+              onClick={() => setPage(p => p + 1)}
+              disabled={page === pageCount - 1}
+            >Next ›</button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/themes/classic/ClassicRoot.jsx
+++ b/src/themes/classic/ClassicRoot.jsx
@@ -64,6 +64,7 @@ function ClassicRoot({ dictionary, onHowToPlay, onLogin, onSettings }) {
         boardCleared={boardCleared}
         tilesOnBoard={tilesOnBoard}
         wordStats={state.wordStats}
+        allWordsThisGame={state.allWordsThisGame}
         onRestart={handleRestart}
       />
       <DebugOverlay />

--- a/src/themes/classic/components/Overlays/GameOverOverlay.jsx
+++ b/src/themes/classic/components/Overlays/GameOverOverlay.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState, useMemo } from 'react';
+import WordListModal from '../../../../shared/overlays/WordListModal.jsx';
 
 function GameStatsBullets({ wordStats, intro }) {
   if (!wordStats) return <div className="word-stats-loading">Loading stats…</div>;
@@ -23,7 +24,10 @@ function GameStatsBullets({ wordStats, intro }) {
   );
 }
 
-function GameOverOverlay({ visible, gameMode, score, lettersRemaining = 0, boardCleared = false, tilesOnBoard = 0, wordStats, onRestart }) {
+function GameOverOverlay({ visible, gameMode, score, lettersRemaining = 0, boardCleared = false, tilesOnBoard = 0, wordStats, allWordsThisGame = [], onRestart }) {
+  const [showWordList, setShowWordList] = useState(false);
+  const newWordsSet = useMemo(() => new Set(wordStats?.newWords ?? []), [wordStats]);
+
   if (!visible) return null;
 
   const isClearMode = gameMode === 'clear';
@@ -62,10 +66,27 @@ function GameOverOverlay({ visible, gameMode, score, lettersRemaining = 0, board
         {wordStats !== undefined && (
           <GameStatsBullets wordStats={wordStats} intro={statsIntro} />
         )}
+        {allWordsThisGame.length > 0 && (
+          <button
+            className="game-over-restart-btn"
+            style={{ marginTop: 8, background: 'transparent', color: '#2e7d32', border: '1px solid #2e7d32' }}
+            onClick={() => setShowWordList(true)}
+          >
+            See all {allWordsThisGame.length} words →
+          </button>
+        )}
         <button className="game-over-restart-btn" onClick={onRestart}>
           Home
         </button>
       </div>
+      {showWordList && (
+        <WordListModal
+          words={allWordsThisGame}
+          newWords={newWordsSet}
+          onClose={() => setShowWordList(false)}
+          title={`Words This Game (${allWordsThisGame.length})`}
+        />
+      )}
     </div>
   );
 }

--- a/src/themes/redesign/screens/GameOver.jsx
+++ b/src/themes/redesign/screens/GameOver.jsx
@@ -1,6 +1,8 @@
+import { useState, useMemo } from 'react';
 import { useGame } from '../../../context/GameContext.jsx';
 import { A } from '../../../utils/actionTypes.js';
 import { TOTAL_LETTERS } from '../../../utils/gameConstants.js';
+import WordListModal from '../../../shared/overlays/WordListModal.jsx';
 
 function WordStatsBullets({ wordStats, intro }) {
   if (!wordStats) return <div className="rd-word-stats-loading">Loading stats…</div>;
@@ -27,6 +29,8 @@ function WordStatsBullets({ wordStats, intro }) {
 
 function GameOver() {
   const { state, dispatch } = useGame();
+  const [showWordList, setShowWordList] = useState(false);
+  const newWordsSet = useMemo(() => new Set(state.wordStats?.newWords ?? []), [state.wordStats]);
 
   const isClearMode = state.gameMode === 'clear';
   const lettersRemaining = state.lettersRemaining;
@@ -55,9 +59,11 @@ function GameOver() {
     statsIntro = "Along the way, you've:";
   }
 
+  const wordCount = state.allWordsThisGame.length;
+
   const stats = [
     { label: 'Score',      value: state.score },
-    { label: 'Words made', value: state.madeWords.length },
+    { label: 'Words made', value: wordCount },
   ];
 
   const onHome = () => dispatch({ type: A.RESET });
@@ -85,6 +91,12 @@ function GameOver() {
           <WordStatsBullets wordStats={state.wordStats} intro={statsIntro} />
         )}
 
+        {wordCount > 0 && (
+          <button type="button" className="rd-link-btn" onClick={() => setShowWordList(true)}>
+            See all {wordCount} words →
+          </button>
+        )}
+
         <div className="rd-gameover__actions">
           <button type="button" className="rd-cta" onClick={onRestart}>
             Play Again
@@ -94,6 +106,15 @@ function GameOver() {
           </button>
         </div>
       </div>
+
+      {showWordList && (
+        <WordListModal
+          words={state.allWordsThisGame}
+          newWords={newWordsSet}
+          onClose={() => setShowWordList(false)}
+          title={`Words This Game (${wordCount})`}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **`WordListModal`** — new shared overlay with search bar, 15-words-per-page pagination, and definition cards; "NEW" badge for first-time words
- **Game-over screens** (both redesign & classic) — "See all X words →" button opens the modal with this game's full deduplicated word list
- **`GET /api/vocabulary`** — new endpoint querying the existing `word_history` table, returning all words for a user alphabetically
- **Settings → Vocabulary** — new panel that fetches lifetime word history and opens the modal

## Test plan

- [x] Play a game, reach game over → "See all X words" button is visible with correct count
- [x] Click button → modal opens with alphabetically sorted words and definitions
- [x] Search for a word → list filters in real time, pagination hides
- [x] Use Prev/Next → pages advance correctly, buttons disable at boundaries
- [x] New words show "NEW" badge
- [x] Open Settings → Vocabulary → lifetime word list loads and is browsable
- [x] Classic theme game-over shows the same button and modal
- [ ] `curl "localhost:3000/api/vocabulary?username=<name>"` returns alphabetically sorted words

🤖 Generated with [Claude Code](https://claude.com/claude-code)