### PR TITLE
feat: show logged-in state on login button in both themes

### DIFF
--- a/src/shared/hooks/useCurrentUser.js
+++ b/src/shared/hooks/useCurrentUser.js
@@ -1,0 +1,17 @@
+import { useState, useEffect } from 'react';
+
+export const NOODEL_LOGIN_EVENT = 'noodel-login';
+
+export function useCurrentUser() {
+  const [currentUser, setCurrentUser] = useState(
+    () => localStorage.getItem('noodel_username')
+  );
+
+  useEffect(() => {
+    const handler = () => setCurrentUser(localStorage.getItem('noodel_username'));
+    window.addEventListener(NOODEL_LOGIN_EVENT, handler);
+    return () => window.removeEventListener(NOODEL_LOGIN_EVENT, handler);
+  }, []);
+
+  return currentUser;
+}

--- a/src/shared/hooks/useSettingsState.js
+++ b/src/shared/hooks/useSettingsState.js
@@ -21,6 +21,11 @@ export function useSettingsState({ onPlayReplay, onClose } = {}) {
     setPanel(null);
   }
 
+  function logout() {
+    localStorage.removeItem('noodel_username');
+    setCurrentUser(null);
+  }
+
   async function openStats() {
     setPanel('stats');
     setLoadingStats(true);
@@ -82,7 +87,7 @@ export function useSettingsState({ onPlayReplay, onClose } = {}) {
 
   return {
     panel, setPanel,
-    currentUser, selectUser,
+    currentUser, selectUser, logout,
     stats, loadingStats, openStats,
     scores, loadingScores, openLeaderboard,
     handleReplay,

--- a/src/shared/icons/ActionIcons.jsx
+++ b/src/shared/icons/ActionIcons.jsx
@@ -24,6 +24,15 @@ export function LoginIcon(props) {
   );
 }
 
+export function LoggedInIcon(props) {
+  return (
+    <svg {...ICON_PROPS} {...props}>
+      <path fill="currentColor" stroke="none" d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+      <circle fill="currentColor" stroke="none" cx="12" cy="7" r="4" />
+    </svg>
+  );
+}
+
 export function HomeIcon(props) {
   return (
     <svg {...ICON_PROPS} {...props}>

--- a/src/shared/overlays/LoginMenu.jsx
+++ b/src/shared/overlays/LoginMenu.jsx
@@ -1,4 +1,5 @@
 import { useSettingsState, USERS } from '../hooks/useSettingsState.js';
+import { NOODEL_LOGIN_EVENT } from '../hooks/useCurrentUser.js';
 import './SettingsMenu.css';
 
 function LoginMenu({ onClose }) {
@@ -6,6 +7,7 @@ function LoginMenu({ onClose }) {
 
   const handleSelect = (name) => {
     s.selectUser(name);
+    window.dispatchEvent(new CustomEvent(NOODEL_LOGIN_EVENT));
     onClose?.();
   };
 

--- a/src/shared/overlays/LoginMenu.jsx
+++ b/src/shared/overlays/LoginMenu.jsx
@@ -11,6 +11,12 @@ function LoginMenu({ onClose }) {
     onClose?.();
   };
 
+  const handleLogout = () => {
+    s.logout();
+    window.dispatchEvent(new CustomEvent(NOODEL_LOGIN_EVENT));
+    onClose?.();
+  };
+
   return (
     <div className="settings-menu" onClick={onClose}>
       <div className="settings-menu__card" onClick={e => e.stopPropagation()}>
@@ -32,6 +38,14 @@ function LoginMenu({ onClose }) {
               <span>{s.currentUser === name ? '✓ ' : ''}{name.charAt(0).toUpperCase() + name.slice(1)}</span>
             </button>
           ))}
+          {s.currentUser && (
+            <button
+              className="settings-menu__btn settings-menu__btn--logout"
+              onClick={handleLogout}
+            >
+              Log out
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/src/shared/overlays/SettingsMenu.css
+++ b/src/shared/overlays/SettingsMenu.css
@@ -105,6 +105,17 @@
   background: #E8F5E9;
   color: #2E7D32;
 }
+.settings-menu__btn--logout {
+  color: #9ca3af;
+  font-weight: 500;
+  justify-content: center;
+  margin-top: 4px;
+}
+.settings-menu__btn--logout:hover {
+  color: #ef4444;
+  border-color: #fca5a5;
+  background: #fff5f5;
+}
 
 .settings-menu__theme span {
   display: flex;

--- a/src/themes/classic/components/Layout/GameLayout.jsx
+++ b/src/themes/classic/components/Layout/GameLayout.jsx
@@ -5,7 +5,8 @@ import NextPreview from '../Controls/NextPreview.jsx';
 import Board from '../Grid/Board.jsx';
 import MadeWords from '../Stats/MadeWords.jsx';
 import DroppingOverlay from '../../../../shared/overlays/DroppingOverlay.jsx';
-import { HowToPlayIcon, LoginIcon, SettingsIcon } from '../../../../shared/icons/ActionIcons.jsx';
+import { HowToPlayIcon, LoginIcon, LoggedInIcon, SettingsIcon } from '../../../../shared/icons/ActionIcons.jsx';
+import { useCurrentUser } from '../../../../shared/hooks/useCurrentUser.js';
 import { GRID_COLS, GRID_ROWS } from '../../../../utils/gameConstants.js';
 import { useAmbientDemo } from '../../../../hooks/useAmbientDemo.js';
 import StartGameOverlay from '../../../../shared/components/StartGameOverlay.jsx';
@@ -29,6 +30,7 @@ function GameLayout({
   onStartGame,
   showPreview = false,
 }) {
+  const currentUser = useCurrentUser();
   const gridRef = useRef(null);
   const nextUpRef = useRef(null);
 
@@ -173,8 +175,14 @@ function GameLayout({
         </div>
         <div className="app-bar__center" />
         <div className="app-bar__side app-bar__side--right">
-          <button className="action-btn login-btn" onClick={onLogin} title="Log in" aria-label="Log in">
-            <LoginIcon />
+          <button
+            className={`action-btn login-btn${currentUser ? ' login-btn--loggedin' : ''}`}
+            onClick={onLogin}
+            title={currentUser ?? 'Log in'}
+            aria-label={currentUser ? `Logged in as ${currentUser}` : 'Log in'}
+          >
+            {currentUser ? <LoggedInIcon /> : <LoginIcon />}
+            {currentUser && <span className="login-btn__username">{currentUser}</span>}
           </button>
           <button className="action-btn settings-btn" onClick={onSettings} title="Settings" aria-label="Settings">
             <SettingsIcon />

--- a/src/themes/classic/components/Layout/GameLayout.jsx
+++ b/src/themes/classic/components/Layout/GameLayout.jsx
@@ -175,15 +175,23 @@ function GameLayout({
         </div>
         <div className="app-bar__center" />
         <div className="app-bar__side app-bar__side--right">
-          <button
-            className={`action-btn login-btn${currentUser ? ' login-btn--loggedin' : ''}`}
-            onClick={onLogin}
-            title={currentUser ?? 'Log in'}
-            aria-label={currentUser ? `Logged in as ${currentUser}` : 'Log in'}
-          >
-            {currentUser ? <LoggedInIcon /> : <LoginIcon />}
-            {currentUser && <span className="login-btn__username">{currentUser}</span>}
-          </button>
+          {currentUser ? (
+            <div className="login-wrapper">
+              <button
+                className="action-btn login-btn login-btn--loggedin"
+                onClick={onLogin}
+                title={currentUser}
+                aria-label={`Logged in as ${currentUser}`}
+              >
+                <LoggedInIcon />
+              </button>
+              <span className="login-wrapper__username">{currentUser}</span>
+            </div>
+          ) : (
+            <button className="action-btn login-btn" onClick={onLogin} title="Log in" aria-label="Log in">
+              <LoginIcon />
+            </button>
+          )}
           <button className="action-btn settings-btn" onClick={onSettings} title="Settings" aria-label="Settings">
             <SettingsIcon />
           </button>

--- a/src/themes/classic/components/Layout/GameLayout.jsx
+++ b/src/themes/classic/components/Layout/GameLayout.jsx
@@ -175,23 +175,20 @@ function GameLayout({
         </div>
         <div className="app-bar__center" />
         <div className="app-bar__side app-bar__side--right">
-          {currentUser ? (
-            <div className="login-wrapper">
-              <button
-                className="action-btn login-btn login-btn--loggedin"
-                onClick={onLogin}
-                title={currentUser}
-                aria-label={`Logged in as ${currentUser}`}
-              >
-                <LoggedInIcon />
-              </button>
-              <span className="login-wrapper__username">{currentUser}</span>
-            </div>
-          ) : (
-            <button className="action-btn login-btn" onClick={onLogin} title="Log in" aria-label="Log in">
-              <LoginIcon />
+          <div className="login-wrapper">
+            <button
+              className={`action-btn login-btn${currentUser ? ' login-btn--loggedin' : ''}`}
+              onClick={onLogin}
+              title={currentUser ?? 'Log in'}
+              aria-label={currentUser ? `Logged in as ${currentUser}` : 'Log in'}
+            >
+              {currentUser ? <LoggedInIcon /> : <LoginIcon />}
             </button>
-          )}
+            <span className="login-wrapper__username" aria-hidden={!currentUser}
+              style={currentUser ? undefined : { visibility: 'hidden' }}>
+              {currentUser ?? 'x'}
+            </span>
+          </div>
           <button className="action-btn settings-btn" onClick={onSettings} title="Settings" aria-label="Settings">
             <SettingsIcon />
           </button>

--- a/src/themes/classic/styles/card.css
+++ b/src/themes/classic/styles/card.css
@@ -175,7 +175,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    line-height: 1;
+    line-height: 1.4;
     color: var(--color-text-secondary);
 }
 

--- a/src/themes/classic/styles/card.css
+++ b/src/themes/classic/styles/card.css
@@ -160,23 +160,23 @@
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-.login-btn--loggedin {
-    aspect-ratio: unset;
-    height: auto;
+.login-wrapper {
+    display: flex;
     flex-direction: column;
-    gap: 2px;
-    padding: 4px 6px;
+    align-items: center;
+    gap: 3px;
 }
 
-.login-btn__username {
+.login-wrapper__username {
     font-size: 9px;
     font-weight: 600;
     letter-spacing: 0.03em;
-    max-width: 48px;
+    max-width: 40px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
     line-height: 1;
+    color: var(--color-text-secondary);
 }
 
 /* Compact inline score / objective pill */

--- a/src/themes/classic/styles/card.css
+++ b/src/themes/classic/styles/card.css
@@ -160,6 +160,25 @@
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
+.login-btn--loggedin {
+    aspect-ratio: unset;
+    height: auto;
+    flex-direction: column;
+    gap: 2px;
+    padding: 4px 6px;
+}
+
+.login-btn__username {
+    font-size: 9px;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    max-width: 48px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    line-height: 1;
+}
+
 /* Compact inline score / objective pill */
 .stat-group {
     display: inline-flex;

--- a/src/themes/redesign/components/ActionBar.jsx
+++ b/src/themes/redesign/components/ActionBar.jsx
@@ -23,7 +23,7 @@ function ActionBar({ items, className = '' }) {
           <button
             key={id}
             type="button"
-            className={`rd-action-btn${isLogin && currentUser ? ' rd-action-btn--loggedin' : ''}`}
+            className={`rd-action-btn${isLogin ? ' rd-action-btn--login' : ''}${isLogin && currentUser ? ' rd-action-btn--loggedin' : ''}`}
             onClick={onClick || defaultHandler}
             aria-label={isLogin && currentUser ? `Logged in as ${currentUser}` : label}
           >

--- a/src/themes/redesign/components/ActionBar.jsx
+++ b/src/themes/redesign/components/ActionBar.jsx
@@ -1,4 +1,5 @@
-import { HowToPlayIcon, LoginIcon, SettingsIcon } from '../../../shared/icons/ActionIcons.jsx';
+import { HowToPlayIcon, LoginIcon, LoggedInIcon, SettingsIcon } from '../../../shared/icons/ActionIcons.jsx';
+import { useCurrentUser } from '../../../shared/hooks/useCurrentUser.js';
 
 const ITEM_DEFS = {
   howtoplay: { label: 'How to Play', Icon: HowToPlayIcon, defaultHandler: () => console.log('how to play') },
@@ -7,19 +8,24 @@ const ITEM_DEFS = {
 };
 
 function ActionBar({ items, className = '' }) {
+  const currentUser = useCurrentUser();
+
   return (
     <nav className={`rd-action-bar ${className}`} aria-label="Primary actions">
       {items.map(({ id, onClick }) => {
         const def = ITEM_DEFS[id];
         if (!def) return null;
-        const { label, Icon, defaultHandler } = def;
+        const { defaultHandler } = def;
+        const isLogin = id === 'login';
+        const Icon = isLogin && currentUser ? LoggedInIcon : def.Icon;
+        const label = isLogin && currentUser ? currentUser : def.label;
         return (
           <button
             key={id}
             type="button"
-            className="rd-action-btn"
+            className={`rd-action-btn${isLogin && currentUser ? ' rd-action-btn--loggedin' : ''}`}
             onClick={onClick || defaultHandler}
-            aria-label={label}
+            aria-label={isLogin && currentUser ? `Logged in as ${currentUser}` : label}
           >
             <Icon />
             <span className="rd-action-btn__label">{label}</span>

--- a/src/themes/redesign/styles/redesign.css
+++ b/src/themes/redesign/styles/redesign.css
@@ -444,7 +444,7 @@ button {
   height: clamp(14px, 3.5vw, 18px);
 }
 
-.rd-action-btn--loggedin .rd-action-btn__label {
+.rd-action-btn--login .rd-action-btn__label {
   display: inline-block;
   width: 56px;
   overflow: hidden;

--- a/src/themes/redesign/styles/redesign.css
+++ b/src/themes/redesign/styles/redesign.css
@@ -444,11 +444,9 @@ button {
   height: clamp(14px, 3.5vw, 18px);
 }
 
-.rd-action-btn--loggedin {
-  min-width: 100px;
-}
 .rd-action-btn--loggedin .rd-action-btn__label {
-  max-width: 68px;
+  display: inline-block;
+  width: 56px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/themes/redesign/styles/redesign.css
+++ b/src/themes/redesign/styles/redesign.css
@@ -450,6 +450,7 @@ button {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  line-height: 1.4;
 }
 
 .rd-wordmark {

--- a/src/themes/redesign/styles/redesign.css
+++ b/src/themes/redesign/styles/redesign.css
@@ -444,6 +444,13 @@ button {
   height: clamp(14px, 3.5vw, 18px);
 }
 
+.rd-action-btn--loggedin .rd-action-btn__label {
+  max-width: 72px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .rd-wordmark {
   display: inline-flex;
   flex-direction: column;

--- a/src/themes/redesign/styles/redesign.css
+++ b/src/themes/redesign/styles/redesign.css
@@ -444,8 +444,11 @@ button {
   height: clamp(14px, 3.5vw, 18px);
 }
 
+.rd-action-btn--loggedin {
+  min-width: 100px;
+}
 .rd-action-btn--loggedin .rd-action-btn__label {
-  max-width: 72px;
+  max-width: 68px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a filled person icon and username label to the login button when a user is selected
- Works in both Classic and Modern (redesign) themes without prop drilling
- Uses a `useCurrentUser` hook that listens for a custom `noodel-login` event fired by `LoginMenu` on selection

## Test plan

- [x] Log out (clear localStorage) — login button shows outline icon, no username — Classic theme
- [x] Log out — same in Modern theme
- [x] Select a user in the login menu — button immediately shows filled icon + username — Classic theme
- [x] Select a user — same in Modern theme
- [x] Refresh page — logged-in state persists
- [x] Switch themes mid-session — logged-in state visible in both

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)