### PR TITLE
feat: daily game with seeded RNG and daily leaderboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "concurrently": "^9.2.1",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "puppeteer": "^25.0.4",
         "vite": "^5.0.8"
       },
       "engines": {
@@ -1384,6 +1385,72 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@puppeteer/browsers": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.0.3.tgz",
+      "integrity": "sha512-v3YaiGpzUTgOZkHBFR0iZg58Vto25SqBQxfLUXDiofJccwVl6Mlr7BdLCS1NZgxikdeIHf936cxYWL9IZp3tow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "progress": "^2.0.3",
+        "semver": "^7.7.4",
+        "tar-fs": "^3.1.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/main-cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "proxy-agent": ">=8.0.1"
+      },
+      "peerDependenciesMeta": {
+        "proxy-agent": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@puppeteer/browsers/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -2239,6 +2306,103 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bare-events": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
+      "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
@@ -2454,6 +2618,23 @@
         "node": ">=10"
       }
     },
+    "node_modules/chromium-bidi": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-16.0.1.tgz",
+      "integrity": "sha512-J63PGu/9PpeCwLIcKYyzWP6yaVL5pxuBc0shlYCYM8BaAkmlwiQboXO1iNbOgSDbVklEyYFfNEcHD8oOAWacUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=20.19.0 <22.0.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
     "node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -2634,6 +2815,53 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
     },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+      "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/cosmiconfig/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -2793,6 +3021,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1608973",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
+      "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
@@ -2885,6 +3120,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -2896,6 +3141,16 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/error-ex": {
@@ -3084,6 +3339,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -3189,6 +3454,13 @@
         "parseurl": "^1.3.3",
         "serve-static": "^1.16.2"
       }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -3648,6 +3920,33 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/import-local": {
@@ -4833,6 +5132,13 @@
         "node": "*"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -5019,6 +5325,19 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
       "engines": {
         "node": ">=6"
       }
@@ -5335,6 +5654,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -5375,6 +5704,17 @@
         "url": "https://github.com/sponsors/lupomontero"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5384,6 +5724,72 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/puppeteer": {
+      "version": "25.0.4",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.0.4.tgz",
+      "integrity": "sha512-QFdBAuNOqL0I+AdARTlRR1KcgPk0fo0dU127e1ZQFVxb9QPcpBDIiQp/dMgdbyLXHpF2GRjC/OezDmjKcLCKYw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "3.0.3",
+        "chromium-bidi": "16.0.1",
+        "cosmiconfig": "^9.0.0",
+        "devtools-protocol": "0.0.1608973",
+        "puppeteer-core": "25.0.4",
+        "typed-query-selector": "^2.12.2"
+      },
+      "bin": {
+        "puppeteer": "lib/puppeteer/node/cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "25.0.4",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.0.4.tgz",
+      "integrity": "sha512-K1LQKDP6w1rIr1jUyN9obH16TO/DCy86k3q+FBd2prGY+TStxhFySxmaZZuRF+0D3BJXjwCYFke7tMHCH4olTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "3.0.3",
+        "chromium-bidi": "16.0.1",
+        "debug": "^4.4.3",
+        "devtools-protocol": "0.0.1608973",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.1",
+        "ws": "^8.20.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/puppeteer-core/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer-core/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pure-rand": {
       "version": "6.1.0",
@@ -5935,6 +6341,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -6043,6 +6461,59 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tar-stream/node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -6056,6 +6527,31 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/text-decoder/node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/tmpl": {
@@ -6167,6 +6663,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.16.0",
@@ -6352,6 +6855,13 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+      "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -6469,9 +6979,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6573,6 +7083,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "concurrently": "^9.2.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "puppeteer": "^25.0.4",
     "vite": "^5.0.8"
   },
   "keywords": [

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -18,6 +18,12 @@ try {
   await pool.query(`
     ALTER TABLE leaderboard ADD COLUMN IF NOT EXISTS session_data JSONB;
   `);
+  await pool.query(`
+    ALTER TABLE leaderboard ADD COLUMN IF NOT EXISTS game_date DATE NOT NULL DEFAULT CURRENT_DATE;
+  `);
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS leaderboard_game_date_idx ON leaderboard (game_date);
+  `);
   console.log('✅ leaderboard table ready');
   await pool.query(`
     CREATE TABLE IF NOT EXISTS word_history (

--- a/server.js
+++ b/server.js
@@ -88,8 +88,18 @@ app.post('/api/scores', async (req, res) => {
 
 app.get('/api/scores', async (req, res) => {
   try {
+    const username = req.query.username || '';
     const result = await pool.query(
-      'SELECT id, username, score, game_mode, created_at FROM leaderboard ORDER BY score DESC LIMIT 10'
+      `WITH ranked AS (
+        SELECT id, username, score, game_mode, created_at,
+               RANK() OVER (ORDER BY score DESC)::int AS rank
+        FROM leaderboard
+        WHERE game_date = CURRENT_DATE
+      )
+      SELECT * FROM ranked
+      WHERE rank <= 5 OR username = $1
+      ORDER BY rank`,
+      [username]
     );
     res.json(result.rows);
   } catch (err) {

--- a/src/context/GameContext.jsx
+++ b/src/context/GameContext.jsx
@@ -2,6 +2,7 @@ import React, { createContext, useReducer, useContext, useCallback, useEffect, u
 import { gameReducer, initialState } from './GameReducer.js';
 import { generateLetterSequence } from '../utils/letterUtils.js';
 import { generateClearModeGrid } from '../utils/clearModeUtils.js';
+import { createSeededRng, getDailyDateSeed } from '../utils/seededRandom.js';
 import { TOTAL_LETTERS, STATUS } from '../utils/gameConstants.js';
 import { A } from '../utils/actionTypes.js';
 import { createRecorder } from '../services/sessionRecorder.js';
@@ -9,8 +10,8 @@ import * as sessionStorage from '../services/sessionStorage.js';
 
 const GameContext = createContext(null);
 
-function buildInitialQueue(mode) {
-  let seq = generateLetterSequence(TOTAL_LETTERS);
+function buildInitialQueue(mode, rng) {
+  let seq = generateLetterSequence(TOTAL_LETTERS, rng);
   if (mode === 'tutorial') {
     seq = [
       { char: 'W', id: 'tutorial-W-1' },
@@ -29,8 +30,8 @@ function buildInitialQueue(mode) {
   return seq;
 }
 
-function buildInitialGrid(mode) {
-  if (mode === 'clear') return generateClearModeGrid();
+function buildInitialGrid(mode, rng) {
+  if (mode === 'clear') return generateClearModeGrid(rng);
   return { grid: null, initialBlocks: [] };
 }
 
@@ -67,8 +68,9 @@ export function GameProvider({ children }) {
     if (action.type === A.START_GAME) {
       scoreSubmittedRef.current = false;
       const { mode } = action.payload;
-      const initialQueue = buildInitialQueue(mode);
-      const { grid: initialGrid, initialBlocks } = buildInitialGrid(mode);
+      const rng = createSeededRng(getDailyDateSeed());
+      const initialQueue = buildInitialQueue(mode, rng);
+      const { grid: initialGrid, initialBlocks } = buildInitialGrid(mode, rng);
       const fullAction = { type: A.START_GAME, payload: { mode, initialQueue, initialGrid, initialBlocks } };
       recorderRef.current.record(fullAction);
       dispatch(fullAction);

--- a/src/shared/components/StartGameOverlay.jsx
+++ b/src/shared/components/StartGameOverlay.jsx
@@ -1,8 +1,9 @@
-function StartGameOverlay({ onClick, className = '' }) {
+function StartGameOverlay({ onClick, className = '', date }) {
   return (
     <div className={`start-game-overlay${className ? ' ' + className : ''}`}>
       <button type="button" className="start-game-btn" onClick={onClick}>
         Start Game
+        {date && <span className="start-game-btn__date">{date}</span>}
       </button>
     </div>
   );

--- a/src/shared/hooks/useSettingsState.js
+++ b/src/shared/hooks/useSettingsState.js
@@ -44,7 +44,8 @@ export function useSettingsState({ onPlayReplay, onClose } = {}) {
     setPanel('leaderboard');
     setLoadingScores(true);
     try {
-      const res = await fetch('/api/scores');
+      const username = localStorage.getItem('noodel_username') ?? '';
+      const res = await fetch(`/api/scores?username=${encodeURIComponent(username)}`);
       setScores(await res.json());
     } catch {
       setScores([]);

--- a/src/shared/overlays/SettingsMenu.css
+++ b/src/shared/overlays/SettingsMenu.css
@@ -206,3 +206,25 @@
   background: #388E3C;
   color: #ffffff;
 }
+
+.settings-menu__date {
+  padding: 8px 8px;
+  font-size: 13px;
+  color: #9ca3af;
+  margin-bottom: 4px;
+}
+
+.settings-menu__separator {
+  padding: 8px 8px;
+  text-align: center;
+  color: #d1d5db;
+  font-size: 12px;
+}
+
+.settings-menu__row.is-user {
+  background-color: #f0fdf4;
+}
+
+.settings-menu__row.is-user .settings-menu__rank {
+  color: #16a34a;
+}

--- a/src/shared/overlays/SettingsMenu.jsx
+++ b/src/shared/overlays/SettingsMenu.jsx
@@ -1,6 +1,7 @@
 import { useSettingsState } from '../hooks/useSettingsState.js';
 import { useTheme } from '../../themes/ThemeContext.jsx';
 import { useGame } from '../../context/GameContext.jsx';
+import { formatDailyDate } from '../../utils/seededRandom.js';
 import { STATUS } from '../../utils/gameConstants.js';
 import { A } from '../../utils/actionTypes.js';
 import WordListModal from './WordListModal.jsx';
@@ -127,25 +128,32 @@ function SettingsMenu({ onClose, isMuted, onToggleMute, onPlayReplay }) {
 
         {s.panel === 'leaderboard' && (
           <div>
+            <div className="settings-menu__date">{formatDailyDate()}</div>
             {s.loadingScores ? (
               <p className="settings-menu__empty">Loading…</p>
             ) : s.scores.length === 0 ? (
               <p className="settings-menu__empty">No scores yet.</p>
             ) : (
               <div className="settings-menu__leaderboard">
-                {s.scores.slice(0, 25).map((row, i) => (
-                  <div key={row.id} className="settings-menu__row">
-                    <span className="settings-menu__rank">#{i + 1}</span>
-                    <span className="settings-menu__name">{row.username || 'anonymous'}</span>
-                    <span className="settings-menu__score">{row.score}</span>
-                    <button
-                      type="button"
-                      className="settings-menu__replay"
-                      onClick={() => s.handleReplay(row.id)}
-                      aria-label="Play replay"
-                    >▶</button>
-                  </div>
-                ))}
+                {s.scores.map((row, i, arr) => {
+                  const isUser = row.username === s.currentUser;
+                  const prevRank = arr[i - 1]?.rank ?? 0;
+                  const showSeparator = row.rank > 5 && prevRank <= 5;
+                  return [
+                    showSeparator && <div key={`sep-${row.id}`} className="settings-menu__separator">···</div>,
+                    <div key={row.id} className={`settings-menu__row${isUser ? ' is-user' : ''}`}>
+                      <span className="settings-menu__rank">#{row.rank}</span>
+                      <span className="settings-menu__name">{row.username || 'anonymous'}</span>
+                      <span className="settings-menu__score">{row.score}</span>
+                      <button
+                        type="button"
+                        className="settings-menu__replay"
+                        onClick={() => s.handleReplay(row.id)}
+                        aria-label="Play replay"
+                      >▶</button>
+                    </div>
+                  ];
+                }).flat()}
               </div>
             )}
             <button className="settings-menu__btn" onClick={() => s.setPanel(null)} style={{ marginTop: 12 }}>← Back</button>

--- a/src/themes/classic/components/Layout/GameLayout.jsx
+++ b/src/themes/classic/components/Layout/GameLayout.jsx
@@ -9,6 +9,7 @@ import { HowToPlayIcon, LoginIcon, LoggedInIcon, SettingsIcon } from '../../../.
 import { useCurrentUser } from '../../../../shared/hooks/useCurrentUser.js';
 import { GRID_COLS, GRID_ROWS } from '../../../../utils/gameConstants.js';
 import { useAmbientDemo } from '../../../../hooks/useAmbientDemo.js';
+import { formatDailyDate } from '../../../../utils/seededRandom.js';
 import StartGameOverlay from '../../../../shared/components/StartGameOverlay.jsx';
 
 function GameLayout({
@@ -217,7 +218,7 @@ function GameLayout({
         </div>
         <Board grid={displayGrid} onColumnClick={isIdle ? null : handleColumnClick} gridRef={gridRef} visible={true} />
         {gameStatus === 'IDLE' && (
-          <StartGameOverlay className="start-game-overlay--classic" onClick={onStartGame} />
+          <StartGameOverlay className="start-game-overlay--classic" date={formatDailyDate()} onClick={onStartGame} />
         )}
       </div>
 

--- a/src/themes/redesign/screens/Landing.jsx
+++ b/src/themes/redesign/screens/Landing.jsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react';
 import { useGame } from '../../../context/GameContext.jsx';
 import { A } from '../../../utils/actionTypes.js';
+import { formatDailyDate } from '../../../utils/seededRandom.js';
 import ActionBar from '../components/ActionBar.jsx';
 import NextRow from '../components/NextRow.jsx';
 import { useAmbientDemo, AmbientBoard } from '../components/AmbientDemo.jsx';
@@ -39,6 +40,7 @@ function Landing({ onHowToPlay, onLogin, onSettings }) {
           <AmbientBoard {...demo} firstTileRef={firstTileRef} />
           <StartGameOverlay
             className="start-game-overlay--redesign"
+            date={formatDailyDate()}
             onClick={() => dispatch({ type: A.START_GAME, payload: { mode: 'clear' } })}
           />
         </div>

--- a/src/themes/redesign/styles/redesign.css
+++ b/src/themes/redesign/styles/redesign.css
@@ -563,6 +563,16 @@ button {
   box-shadow: 0 2px 8px rgba(56, 142, 60, 0.30);
 }
 
+.start-game-btn__date {
+  display: block;
+  font-size: 0.7em;
+  font-weight: 400;
+  letter-spacing: 0.04em;
+  opacity: 0.85;
+  text-transform: none;
+  margin-top: 2px;
+}
+
 /* ---------- CTA button (game screens) ---------- */
 
 .rd-cta {

--- a/src/utils/clearModeUtils.js
+++ b/src/utils/clearModeUtils.js
@@ -7,13 +7,13 @@ import { getWeightedRandomLetter } from './letterUtils.js';
  * Initial blocks fall to the bottom of their columns (gravity applied)
  * @returns {Object} { grid: Array, initialBlocks: Array<number> }
  */
-export function generateClearModeGrid() {
+export function generateClearModeGrid(rng = Math.random) {
   const grid = Array(GRID_SIZE).fill(null);
   const cellsToFill = Math.floor(GRID_SIZE * CLEAR_MODE_INITIAL_FILL_PERCENTAGE);
 
   // Generate random letters and place them in random columns
   const initialLetters = Array.from({ length: cellsToFill }, (_, i) => ({
-    char: getWeightedRandomLetter(),
+    char: getWeightedRandomLetter(rng),
     id: `initial-${i}`,
     type: 'filled',
     isMatched: false,
@@ -24,11 +24,11 @@ export function generateClearModeGrid() {
   }));
 
   // Randomly distribute letters across columns
-  const shuffledLetters = initialLetters.sort(() => Math.random() - 0.5);
+  const shuffledLetters = initialLetters.sort(() => rng() - 0.5);
   const lettersPerColumn = Array.from({ length: GRID_COLS }, () => []);
 
   shuffledLetters.forEach(letter => {
-    const randomCol = Math.floor(Math.random() * GRID_COLS);
+    const randomCol = Math.floor(rng() * GRID_COLS);
     lettersPerColumn[randomCol].push(letter);
   });
 

--- a/src/utils/letterUtils.js
+++ b/src/utils/letterUtils.js
@@ -38,8 +38,8 @@ const cumulativeWeights = LETTER_FREQUENCIES.map(item => {
 /**
  * Generate a weighted random letter
  */
-export function getWeightedRandomLetter() {
-  const random = Math.random() * totalWeight;
+export function getWeightedRandomLetter(rng = Math.random) {
+  const random = rng() * totalWeight;
   for (const item of cumulativeWeights) {
     if (random <= item.cumWeight) {
       return item.letter;
@@ -74,16 +74,16 @@ function getConsonantCount(letters) {
  * 1. No letter repeating consecutively
  * 2. No more than 3 consonants in a row
  */
-function getNextValidLetter(previousLetter, consonantCount) {
+function getNextValidLetter(previousLetter, consonantCount, rng = Math.random) {
   // If we have 3 consonants, must pick a vowel
   const mustBeVowel = consonantCount >= MAX_CONSONANTS_IN_ROW;
 
   let letter;
   let attempts = 0;
-  
+
 
   do {
-    letter = getWeightedRandomLetter();
+    letter = getWeightedRandomLetter(rng);
     attempts++;
 
     // Check constraints
@@ -97,13 +97,13 @@ function getNextValidLetter(previousLetter, consonantCount) {
 
   // Fallback: if we exhausted attempts, pick a valid letter directly
   if (mustBeVowel) {
-    return Array.from(VOWELS)[Math.floor(Math.random() * VOWELS.size)];
+    return Array.from(VOWELS)[Math.floor(rng() * VOWELS.size)];
   }
 
   // Just pick something that's not the previous letter
   const consonants = ['B', 'C', 'D', 'F', 'G', 'H', 'J', 'K', 'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'V', 'W', 'X', 'Y', 'Z'];
   const valid = consonants.filter(c => c !== previousLetter);
-  return valid[Math.floor(Math.random() * valid.length)];
+  return valid[Math.floor(rng() * valid.length)];
 }
 
 /**
@@ -111,7 +111,7 @@ function getNextValidLetter(previousLetter, consonantCount) {
  * - No consecutive repeated letters
  * - No more than 3 consecutive consonants
  */
-export function generateLetterSequence(count) {
+export function generateLetterSequence(count, rng = Math.random) {
   const sequence = [];
 
   for (let i = 0; i < count; i++) {
@@ -119,8 +119,8 @@ export function generateLetterSequence(count) {
     const consonantCount = getConsonantCount(sequence);
 
     const letter = previousLetter
-      ? getNextValidLetter(previousLetter, consonantCount)
-      : getWeightedRandomLetter();
+      ? getNextValidLetter(previousLetter, consonantCount, rng)
+      : getWeightedRandomLetter(rng);
 
     sequence.push({
       char: letter,

--- a/src/utils/seededRandom.js
+++ b/src/utils/seededRandom.js
@@ -1,0 +1,36 @@
+/**
+ * Mulberry32 PRNG — deterministic, fast, good distribution.
+ * Returns a function that produces [0, 1) floats.
+ */
+export function createSeededRng(seed) {
+  let s = seed >>> 0;
+  return function () {
+    s = (s + 0x6D2B79F5) >>> 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Returns YYYYMMDD integer for today's local date, used as the daily seed. */
+export function getDailyDateSeed() {
+  const d = new Date();
+  return d.getFullYear() * 10000 + (d.getMonth() + 1) * 100 + d.getDate();
+}
+
+const MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+function ordinal(n) {
+  if (n === 1 || n === 21 || n === 31) return `${n}st`;
+  if (n === 2 || n === 22) return `${n}nd`;
+  if (n === 3 || n === 23) return `${n}rd`;
+  return `${n}th`;
+}
+
+/** Returns a human-readable date string like "May 24th, 2026". */
+export function formatDailyDate(date = new Date()) {
+  return `${MONTH_NAMES[date.getMonth()]} ${ordinal(date.getDate())}, ${date.getFullYear()}`;
+}


### PR DESCRIPTION
Closes #102

## Summary
Converts Noodel from on-demand to a daily game where all players compete on the same puzzle each day. Same tiles for everyone (seeded by date), daily leaderboard reset, and date displayed on start button.

## Changes
- **Seeded RNG**: Mulberry32 PRNG deterministically generates tiles based on YYYYMMDD date
- **Start Game UI**: Button displays date below text (e.g., "May 24th, 2026") in smaller font
- **Database**: Added `game_date` column to leaderboard (defaults to CURRENT_DATE)
- **API**: `/api/scores` now filters by today and returns top 5 + user's rank (with RANK window function)
- **Leaderboard UI**: Shows date header, top 5 scores, separator, and user's rank if outside top 5

## Test plan
- [x] Start Game button displays date in correct format
- [x] Game starts and uses seeded tiles (same tiles every game today)
- [x] Database migration adds game_date column with default
- [x] Scores are stored with game_date = CURRENT_DATE
- [x] API `/api/scores?username=X` returns top 5 + user entries with rank field
- [x] No username: API returns only top 5 scores
- [x] CSS styling applied for date subtitle and user row highlighting

🤖 Generated with [Claude Code](https://claude.com/claude-code)