### PR TITLE
Add daily clear leaderboard on game over and settings enhancements

### DIFF
--- a/scripts/fix_game_dates.sql
+++ b/scripts/fix_game_dates.sql
@@ -1,0 +1,5 @@
+-- Fix game_date for existing scores that had the wrong date
+-- (They were assigned CURRENT_DATE during ALTER TABLE, but should match their created_at date)
+UPDATE leaderboard
+SET game_date = DATE(created_at AT TIME ZONE 'UTC')
+WHERE game_date > DATE(created_at AT TIME ZONE 'UTC');

--- a/server.js
+++ b/server.js
@@ -89,17 +89,26 @@ app.post('/api/scores', async (req, res) => {
 app.get('/api/scores', async (req, res) => {
   try {
     const username = req.query.username || '';
+    const gameMode = req.query.gameMode || '';
+    let dateParam = req.query.date || null;
+
+    // Validate date format if provided
+    if (dateParam && !/^\d{4}-\d{2}-\d{2}$/.test(dateParam)) {
+      return res.status(400).json({ error: 'invalid date format; use YYYY-MM-DD' });
+    }
+
     const result = await pool.query(
       `WITH ranked AS (
-        SELECT id, username, score, game_mode, created_at,
+        SELECT id, username, score, game_mode, created_at, game_date,
                RANK() OVER (ORDER BY score DESC)::int AS rank
         FROM leaderboard
-        WHERE game_date = CURRENT_DATE
+        WHERE game_date = COALESCE($3::date, CURRENT_DATE)
+          AND ($2 = '' OR game_mode = $2)
       )
       SELECT * FROM ranked
       WHERE rank <= 5 OR username = $1
       ORDER BY rank`,
-      [username]
+      [username, gameMode, dateParam]
     );
     res.json(result.rows);
   } catch (err) {
@@ -121,6 +130,24 @@ app.get('/api/scores/:id/session', async (req, res) => {
     res.json(result.rows[0].session_data);
   } catch (err) {
     console.error('GET /api/scores/:id/session error:', err);
+    res.status(500).json({ error: 'internal server error' });
+  }
+});
+
+app.get('/api/scores/my-best', async (req, res) => {
+  try {
+    const username = req.query.username || 'anonymous';
+    const result = await pool.query(
+      `SELECT id, username, score, game_mode, game_date, created_at
+       FROM leaderboard
+       WHERE username = $1
+       ORDER BY score DESC
+       LIMIT 5`,
+      [username]
+    );
+    res.json(result.rows);
+  } catch (err) {
+    console.error('GET /api/scores/my-best error:', err);
     res.status(500).json({ error: 'internal server error' });
   }
 });

--- a/src/shared/hooks/useSettingsState.js
+++ b/src/shared/hooks/useSettingsState.js
@@ -2,6 +2,17 @@ import { useState } from 'react';
 
 export const USERS = ['yiding', 'hannah'];
 
+function getTodayDate() {
+  const d = new Date();
+  return d.toISOString().split('T')[0];
+}
+
+function getDateForDay(day) {
+  const d = new Date();
+  if (day === 'yesterday') d.setDate(d.getDate() - 1);
+  return d.toISOString().split('T')[0];
+}
+
 export function useSettingsState({ onPlayReplay, onClose } = {}) {
   const [panel, setPanel] = useState(null);
   const [currentUser, setCurrentUser] = useState(
@@ -9,8 +20,11 @@ export function useSettingsState({ onPlayReplay, onClose } = {}) {
   );
   const [scores, setScores] = useState([]);
   const [loadingScores, setLoadingScores] = useState(false);
+  const [leaderboardDay, setLeaderboardDay] = useState('today');
   const [stats, setStats] = useState(null);
   const [loadingStats, setLoadingStats] = useState(false);
+  const [myBestScores, setMyBestScores] = useState([]);
+  const [loadingMyBest, setLoadingMyBest] = useState(false);
   const [vocabWords, setVocabWords] = useState([]);
   const [loadingVocab, setLoadingVocab] = useState(false);
   const [showVocab, setShowVocab] = useState(false);
@@ -40,17 +54,50 @@ export function useSettingsState({ onPlayReplay, onClose } = {}) {
     }
   }
 
-  async function openLeaderboard() {
+  async function openLeaderboard(day = 'today') {
+    setLeaderboardDay(day);
     setPanel('leaderboard');
     setLoadingScores(true);
     try {
       const username = localStorage.getItem('noodel_username') ?? '';
-      const res = await fetch(`/api/scores?username=${encodeURIComponent(username)}`);
+      const dateParam = getDateForDay(day);
+      const params = new URLSearchParams({ username, gameMode: 'clear', date: dateParam });
+      const res = await fetch(`/api/scores?${params}`);
       setScores(await res.json());
     } catch {
       setScores([]);
     } finally {
       setLoadingScores(false);
+    }
+  }
+
+  async function switchLeaderboardDay(day) {
+    setLeaderboardDay(day);
+    setLoadingScores(true);
+    try {
+      const username = localStorage.getItem('noodel_username') ?? '';
+      const dateParam = getDateForDay(day);
+      const params = new URLSearchParams({ username, gameMode: 'clear', date: dateParam });
+      const res = await fetch(`/api/scores?${params}`);
+      setScores(await res.json());
+    } catch {
+      setScores([]);
+    } finally {
+      setLoadingScores(false);
+    }
+  }
+
+  async function openMyBest() {
+    setPanel('my-best');
+    setLoadingMyBest(true);
+    try {
+      const username = localStorage.getItem('noodel_username') ?? '';
+      const res = await fetch(`/api/scores/my-best?username=${encodeURIComponent(username)}`);
+      setMyBestScores(await res.json());
+    } catch {
+      setMyBestScores([]);
+    } finally {
+      setLoadingMyBest(false);
     }
   }
 
@@ -90,7 +137,9 @@ export function useSettingsState({ onPlayReplay, onClose } = {}) {
     panel, setPanel,
     currentUser, selectUser, logout,
     stats, loadingStats, openStats,
-    scores, loadingScores, openLeaderboard,
+    scores, loadingScores, openLeaderboard, switchLeaderboardDay,
+    leaderboardDay,
+    myBestScores, loadingMyBest, openMyBest,
     handleReplay,
     vocabWords, loadingVocab, showVocab, setShowVocab, openVocabulary,
   };

--- a/src/shared/overlays/SettingsMenu.jsx
+++ b/src/shared/overlays/SettingsMenu.jsx
@@ -16,6 +16,7 @@ function SettingsMenu({ onClose, isMuted, onToggleMute, onPlayReplay }) {
   const title =
     s.panel === 'stats'       ? 'Stats'
     : s.panel === 'leaderboard' ? 'Leaderboard'
+    : s.panel === 'my-best'   ? 'My Best Games'
     : s.panel === 'theme'     ? 'Theme'
     : 'Settings';
 
@@ -46,8 +47,12 @@ function SettingsMenu({ onClose, isMuted, onToggleMute, onPlayReplay }) {
               <span>📊 Stats</span>
               <span aria-hidden="true">›</span>
             </button>
-            <button className="settings-menu__btn" onClick={s.openLeaderboard}>
+            <button className="settings-menu__btn" onClick={() => s.openLeaderboard()}>
               <span>🏆 Leaderboard</span>
+              <span aria-hidden="true">›</span>
+            </button>
+            <button className="settings-menu__btn" onClick={s.openMyBest}>
+              <span>🥇 My Best</span>
               <span aria-hidden="true">›</span>
             </button>
             <button className="settings-menu__btn" onClick={s.openVocabulary}>
@@ -128,7 +133,27 @@ function SettingsMenu({ onClose, isMuted, onToggleMute, onPlayReplay }) {
 
         {s.panel === 'leaderboard' && (
           <div>
-            <div className="settings-menu__date">{formatDailyDate()}</div>
+            <div style={{ marginBottom: 12, display: 'flex', gap: 8 }}>
+              {['today', 'yesterday'].map(day => (
+                <button
+                  key={day}
+                  onClick={() => s.switchLeaderboardDay(day)}
+                  style={{
+                    flex: 1,
+                    padding: '8px',
+                    backgroundColor: s.leaderboardDay === day ? '#2e7d32' : '#ddd',
+                    color: s.leaderboardDay === day ? 'white' : 'black',
+                    border: 'none',
+                    borderRadius: '4px',
+                    cursor: 'pointer',
+                    fontSize: '0.9em',
+                    fontWeight: s.leaderboardDay === day ? '600' : '400',
+                  }}
+                >
+                  {day.charAt(0).toUpperCase() + day.slice(1)}
+                </button>
+              ))}
+            </div>
             {s.loadingScores ? (
               <p className="settings-menu__empty">Loading…</p>
             ) : s.scores.length === 0 ? (
@@ -154,6 +179,35 @@ function SettingsMenu({ onClose, isMuted, onToggleMute, onPlayReplay }) {
                     </div>
                   ];
                 }).flat()}
+              </div>
+            )}
+            <button className="settings-menu__btn" onClick={() => s.setPanel(null)} style={{ marginTop: 12 }}>← Back</button>
+          </div>
+        )}
+
+        {s.panel === 'my-best' && (
+          <div>
+            {s.loadingMyBest ? (
+              <p className="settings-menu__empty">Loading…</p>
+            ) : s.myBestScores.length === 0 ? (
+              <p className="settings-menu__empty">No scores yet — play a game!</p>
+            ) : (
+              <div className="settings-menu__leaderboard">
+                {s.myBestScores.map((row) => {
+                  const gameDate = row.game_date ? row.game_date.split('T')[0] : '';
+                  return (
+                    <div key={row.id} className="settings-menu__row is-user">
+                      <span className="settings-menu__score">{row.score}</span>
+                      <span style={{ fontSize: '0.8em', color: '#999' }}>{gameDate}</span>
+                      <button
+                        type="button"
+                        className="settings-menu__replay"
+                        onClick={() => s.handleReplay(row.id)}
+                        aria-label="Play replay"
+                      >▶</button>
+                    </div>
+                  );
+                })}
               </div>
             )}
             <button className="settings-menu__btn" onClick={() => s.setPanel(null)} style={{ marginTop: 12 }}>← Back</button>

--- a/src/themes/classic/components/Overlays/GameOverOverlay.jsx
+++ b/src/themes/classic/components/Overlays/GameOverOverlay.jsx
@@ -1,5 +1,6 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import WordListModal from '../../../../shared/overlays/WordListModal.jsx';
+import { formatDailyDate } from '../../../../utils/seededRandom.js';
 
 function GameStatsBullets({ wordStats, intro }) {
   if (!wordStats) return <div className="word-stats-loading">Loading stats…</div>;
@@ -26,11 +27,26 @@ function GameStatsBullets({ wordStats, intro }) {
 
 function GameOverOverlay({ visible, gameMode, score, lettersRemaining = 0, boardCleared = false, tilesOnBoard = 0, wordStats, allWordsThisGame = [], onRestart }) {
   const [showWordList, setShowWordList] = useState(false);
+  const [leaderboard, setLeaderboard] = useState([]);
+  const [loadingLeaderboard, setLoadingLeaderboard] = useState(false);
   const newWordsSet = useMemo(() => new Set(wordStats?.newWords ?? []), [wordStats]);
+
+  const isClearMode = gameMode === 'clear';
+
+  useEffect(() => {
+    if (isClearMode && wordStats !== undefined) {
+      setLoadingLeaderboard(true);
+      const username = localStorage.getItem('noodel_username') ?? '';
+      fetch(`/api/scores?username=${encodeURIComponent(username)}&gameMode=clear`)
+        .then(r => r.json())
+        .then(data => setLeaderboard(data))
+        .catch(() => setLeaderboard([]))
+        .finally(() => setLoadingLeaderboard(false));
+    }
+  }, [isClearMode, wordStats]);
 
   if (!visible) return null;
 
-  const isClearMode = gameMode === 'clear';
   const finalScore = isClearMode ? (100 - lettersRemaining) : score;
   const lettersUsed = 100 - lettersRemaining;
 
@@ -66,6 +82,33 @@ function GameOverOverlay({ visible, gameMode, score, lettersRemaining = 0, board
         {wordStats !== undefined && (
           <GameStatsBullets wordStats={wordStats} intro={statsIntro} />
         )}
+
+        {isClearMode && (
+          <div style={{ marginTop: 16, paddingTop: 16, borderTop: '1px solid #ddd' }}>
+            <h3 style={{ marginBottom: 8, fontSize: '0.95em', fontWeight: 'bold' }}>Today's Clear Leaderboard</h3>
+            {loadingLeaderboard ? (
+              <p style={{ color: '#666', fontSize: '0.9em' }}>Loading…</p>
+            ) : leaderboard.length === 0 ? (
+              <p style={{ color: '#666', fontSize: '0.9em' }}>No scores yet.</p>
+            ) : (
+              <div style={{ fontSize: '0.85em' }}>
+                {leaderboard.map((row, i, arr) => {
+                  const isUser = row.username === (localStorage.getItem('noodel_username') ?? '');
+                  const prevRank = arr[i - 1]?.rank ?? 0;
+                  const showSeparator = row.rank > 5 && prevRank <= 5;
+                  return [
+                    showSeparator && <div key={`sep-${row.id}`} style={{ textAlign: 'center', color: '#999', margin: '4px 0' }}>···</div>,
+                    <div key={row.id} style={{ display: 'flex', justifyContent: 'space-between', padding: '4px 0', backgroundColor: isUser ? '#f0f0f0' : 'transparent' }}>
+                      <span>#{row.rank} {row.username || 'anonymous'}</span>
+                      <span style={{ fontWeight: 'bold' }}>{row.score}</span>
+                    </div>
+                  ];
+                }).flat()}
+              </div>
+            )}
+          </div>
+        )}
+
         {allWordsThisGame.length > 0 && (
           <button
             className="game-over-restart-btn"

--- a/src/themes/redesign/screens/GameOver.jsx
+++ b/src/themes/redesign/screens/GameOver.jsx
@@ -1,7 +1,8 @@
-import { useState, useMemo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useGame } from '../../../context/GameContext.jsx';
 import { A } from '../../../utils/actionTypes.js';
 import { TOTAL_LETTERS } from '../../../utils/gameConstants.js';
+import { formatDailyDate } from '../../../utils/seededRandom.js';
 import WordListModal from '../../../shared/overlays/WordListModal.jsx';
 
 function WordStatsBullets({ wordStats, intro }) {
@@ -30,9 +31,23 @@ function WordStatsBullets({ wordStats, intro }) {
 function GameOver() {
   const { state, dispatch } = useGame();
   const [showWordList, setShowWordList] = useState(false);
+  const [leaderboard, setLeaderboard] = useState([]);
+  const [loadingLeaderboard, setLoadingLeaderboard] = useState(false);
   const newWordsSet = useMemo(() => new Set(state.wordStats?.newWords ?? []), [state.wordStats]);
 
   const isClearMode = state.gameMode === 'clear';
+
+  useEffect(() => {
+    if (isClearMode && state.wordStats !== undefined) {
+      setLoadingLeaderboard(true);
+      const username = localStorage.getItem('noodel_username') ?? '';
+      fetch(`/api/scores?username=${encodeURIComponent(username)}&gameMode=clear`)
+        .then(r => r.json())
+        .then(data => setLeaderboard(data))
+        .catch(() => setLeaderboard([]))
+        .finally(() => setLoadingLeaderboard(false));
+    }
+  }, [isClearMode, state.wordStats]);
   const lettersRemaining = state.lettersRemaining;
   const lettersUsed = TOTAL_LETTERS - lettersRemaining;
   const boardCleared = isClearMode && state.initialBlocks.length > 0
@@ -89,6 +104,32 @@ function GameOver() {
 
         {state.wordStats !== undefined && (
           <WordStatsBullets wordStats={state.wordStats} intro={statsIntro} />
+        )}
+
+        {isClearMode && (
+          <div style={{ marginTop: 24, paddingTop: 16, borderTop: '1px solid #e0e0e0' }}>
+            <h3 style={{ marginBottom: 12, fontSize: '0.95em', fontWeight: 500 }}>Today's Clear Leaderboard</h3>
+            {loadingLeaderboard ? (
+              <p style={{ color: '#666', fontSize: '0.9em' }}>Loading…</p>
+            ) : leaderboard.length === 0 ? (
+              <p style={{ color: '#666', fontSize: '0.9em' }}>No scores yet.</p>
+            ) : (
+              <div style={{ fontSize: '0.85em' }}>
+                {leaderboard.map((row, i, arr) => {
+                  const isUser = row.username === (localStorage.getItem('noodel_username') ?? '');
+                  const prevRank = arr[i - 1]?.rank ?? 0;
+                  const showSeparator = row.rank > 5 && prevRank <= 5;
+                  return [
+                    showSeparator && <div key={`sep-${row.id}`} style={{ textAlign: 'center', color: '#bbb', margin: '6px 0' }}>···</div>,
+                    <div key={row.id} style={{ display: 'flex', justifyContent: 'space-between', padding: '6px 0', backgroundColor: isUser ? '#f5f5f5' : 'transparent', borderRadius: '4px', paddingLeft: isUser ? '6px' : '0' }}>
+                      <span>#{row.rank} <strong>{row.username || 'anonymous'}</strong></span>
+                      <span style={{ fontWeight: 600, color: '#2e7d32' }}>{row.score}</span>
+                    </div>
+                  ];
+                }).flat()}
+              </div>
+            )}
+          </div>
         )}
 
         {wordCount > 0 && (


### PR DESCRIPTION
## Summary

Implements daily leaderboard display on clear mode game over screens and adds settings enhancements for browsing daily/historical leaderboards and personal best scores.

**Key features:**
- Backend API now supports gameMode and date filtering for flexible leaderboard queries
- New GET /api/scores/my-best endpoint returns personal top-5 scores
- Clear mode game over screens show today's leaderboard automatically
- Settings now has Today/Yesterday tabs to view different days
- New "My Best" panel shows personal all-time top scores
- Fixed game_date backfill issue from earlier migration

**Atomic commits:**
1. `feat: add gameMode/date filter and my-best endpoint to leaderboard API` — Backend changes
2. `feat: show daily clear leaderboard on clear mode game over screen` — Post-game UI
3. `feat: add Today/Yesterday tabs and My Best panel to settings` — Settings enhancements
4. `fix: correct game_date for rows backfilled wrong during ALTER TABLE` — Data correction with lessons learned

Closes #104

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>