### PR TITLE
Split start screen into Daily Puzzle and Unlimited Play modes

### DIFF
--- a/src/context/GameContext.jsx
+++ b/src/context/GameContext.jsx
@@ -3,6 +3,7 @@ import { gameReducer, initialState } from './GameReducer.js';
 import { generateLetterSequence } from '../utils/letterUtils.js';
 import { generateClearModeGrid } from '../utils/clearModeUtils.js';
 import { createSeededRng, getDailyDateSeed } from '../utils/seededRandom.js';
+import { markDailyPlayed, consumeUnlimitedPlay } from '../utils/playLimits.js';
 import { TOTAL_LETTERS, STATUS } from '../utils/gameConstants.js';
 import { A } from '../utils/actionTypes.js';
 import { createRecorder } from '../services/sessionRecorder.js';
@@ -67,11 +68,14 @@ export function GameProvider({ children }) {
   const wrappedDispatch = useCallback((action) => {
     if (action.type === A.START_GAME) {
       scoreSubmittedRef.current = false;
-      const { mode } = action.payload;
-      const rng = createSeededRng(getDailyDateSeed());
+      const { mode, gameType } = action.payload;
+      const seed = gameType === 'unlimited' ? Date.now() : getDailyDateSeed();
+      const rng = createSeededRng(seed);
       const initialQueue = buildInitialQueue(mode, rng);
       const { grid: initialGrid, initialBlocks } = buildInitialGrid(mode, rng);
-      const fullAction = { type: A.START_GAME, payload: { mode, initialQueue, initialGrid, initialBlocks } };
+      if (gameType === 'daily') markDailyPlayed();
+      if (gameType === 'unlimited') consumeUnlimitedPlay();
+      const fullAction = { type: A.START_GAME, payload: { mode, gameType, initialQueue, initialGrid, initialBlocks } };
       recorderRef.current.record(fullAction);
       dispatch(fullAction);
       return;
@@ -99,9 +103,11 @@ export function GameProvider({ children }) {
     return true;
   }, [dispatch]);
 
-  // Submit score when game ends.
+  // Submit score when game ends (daily only); always clear the session snapshot.
   useEffect(() => {
-    if (state.status === STATUS.GAME_OVER && !scoreSubmittedRef.current) {
+    if (state.status !== STATUS.GAME_OVER) return;
+    sessionStorage.clear(); // game complete — nothing left to resume
+    if (!scoreSubmittedRef.current && state.gameType === 'daily') {
       scoreSubmittedRef.current = true;
       const username = localStorage.getItem('noodel_username') ?? 'anonymous';
       const fullSnapshot = recorderRef.current.snapshot();
@@ -119,7 +125,6 @@ export function GameProvider({ children }) {
           if (data.wordStats) dispatch({ type: A.SET_WORD_STATS, payload: data.wordStats });
         })
         .catch(() => {}); // don't break the game on DB errors
-      sessionStorage.clear(); // game complete — nothing left to resume
     }
   }, [state.status]);
 

--- a/src/context/GameReducer.js
+++ b/src/context/GameReducer.js
@@ -13,6 +13,7 @@ export const initialState = {
   allWordsThisGame: [], // deduped list of all words cleared this game, for server submission
   wordStats: null, // populated after game-over score submission
   gameMode: null, // null, 'classic', or 'clear'
+  gameType: null, // null, 'daily', or 'unlimited'
   initialBlocks: [] // Array of indices for Clear mode initial blocks
 };
 
@@ -20,7 +21,7 @@ export const initialState = {
 export function gameReducer(state, action) {
   switch (action.type) {
     case A.START_GAME: {
-      const { mode, initialQueue, initialGrid, initialBlocks } = action.payload;
+      const { mode, gameType, initialQueue, initialGrid, initialBlocks } = action.payload;
 
       return {
         ...state,
@@ -33,6 +34,7 @@ export function gameReducer(state, action) {
         allWordsThisGame: [],
         wordStats: null,
         gameMode: mode,
+        gameType: gameType ?? null,
         initialBlocks: initialBlocks || []
       };
     }
@@ -218,7 +220,7 @@ export function gameReducer(state, action) {
     }
 
     case A.LOAD_SAVED_GAME: {
-      const { grid, nextQueue, lettersRemaining, score, madeWords, gameMode, initialBlocks } = action.payload;
+      const { grid, nextQueue, lettersRemaining, score, madeWords, gameMode, gameType, initialBlocks } = action.payload;
       return {
         ...initialState,
         grid,
@@ -227,6 +229,7 @@ export function gameReducer(state, action) {
         score,
         madeWords,
         gameMode,
+        gameType: gameType ?? null,
         initialBlocks: initialBlocks || [],
         status: STATUS.PLAYING
       };

--- a/src/shared/components/GameModePanel.css
+++ b/src/shared/components/GameModePanel.css
@@ -1,0 +1,66 @@
+.game-mode-panel__inner {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: stretch;
+  pointer-events: auto;
+  min-width: 200px;
+  max-width: 240px;
+}
+
+.game-mode-panel__code {
+  text-align: center;
+}
+
+.game-mode-panel__code-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.75em;
+  opacity: 0.6;
+  padding: 2px 0;
+  pointer-events: auto;
+}
+
+.game-mode-panel__code-form {
+  display: flex;
+  gap: 6px;
+  margin-top: 6px;
+  justify-content: center;
+}
+
+.game-mode-panel__code-input {
+  padding: 4px 8px;
+  font-size: 0.85em;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  width: 110px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.game-mode-panel__code-submit {
+  padding: 4px 10px;
+  font-size: 0.85em;
+  border-radius: 4px;
+  background: #2e7d32;
+  color: white;
+  border: none;
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.game-mode-panel__code-msg {
+  font-size: 0.75em;
+  margin: 4px 0 0;
+}
+
+.game-mode-panel__code-msg--ok   { color: #2e7d32; }
+.game-mode-panel__code-msg--err  { color: #c62828; }
+
+.start-game-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+  transform: none !important;
+  box-shadow: none !important;
+}

--- a/src/shared/components/GameModePanel.jsx
+++ b/src/shared/components/GameModePanel.jsx
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+import { A } from '../../utils/actionTypes.js';
+import { formatDailyDate } from '../../utils/seededRandom.js';
+import { hasDailyBeenPlayed, getUnlimitedRemaining, redeemCode } from '../../utils/playLimits.js';
+import './GameModePanel.css';
+
+function GameModePanel({ dispatch, className = '' }) {
+  const [dailyPlayed] = useState(hasDailyBeenPlayed);
+  const [unlimitedLeft, setUnlimitedLeft] = useState(getUnlimitedRemaining);
+  const [showCode, setShowCode] = useState(false);
+  const [codeInput, setCodeInput] = useState('');
+  const [codeMsg, setCodeMsg] = useState('');
+
+  const startDaily = () => {
+    dispatch({ type: A.START_GAME, payload: { mode: 'clear', gameType: 'daily' } });
+  };
+
+  const startUnlimited = () => {
+    if (unlimitedLeft <= 0) return;
+    dispatch({ type: A.START_GAME, payload: { mode: 'clear', gameType: 'unlimited' } });
+  };
+
+  const handleRedeem = () => {
+    const result = redeemCode(codeInput);
+    if (result === 'ok') {
+      setCodeMsg('+10 plays added!');
+      setUnlimitedLeft(getUnlimitedRemaining());
+      setCodeInput('');
+    } else if (result === 'already_used') {
+      setCodeMsg('Already used today.');
+    } else {
+      setCodeMsg('Invalid code.');
+    }
+  };
+
+  const playsLabel = unlimitedLeft === 1 ? '1 play left' : `${unlimitedLeft} plays left`;
+
+  return (
+    <div className={`start-game-overlay${className ? ' ' + className : ''}`}>
+      <div className="game-mode-panel__inner">
+        <button
+          type="button"
+          className="start-game-btn"
+          onClick={startDaily}
+          disabled={dailyPlayed}
+        >
+          Daily Puzzle
+          {dailyPlayed
+            ? <span className="start-game-btn__date">Played today ✓</span>
+            : <span className="start-game-btn__date">{formatDailyDate()}</span>
+          }
+        </button>
+
+        <button
+          type="button"
+          className="start-game-btn"
+          onClick={startUnlimited}
+          disabled={unlimitedLeft === 0}
+        >
+          Unlimited Play
+          <span className="start-game-btn__date">{playsLabel}</span>
+        </button>
+
+        <div className="game-mode-panel__code">
+          <button
+            type="button"
+            className="game-mode-panel__code-toggle"
+            onClick={() => { setShowCode(v => !v); setCodeMsg(''); }}
+          >
+            Have a code? {showCode ? '▲' : '▼'}
+          </button>
+          {showCode && (
+            <div className="game-mode-panel__code-form">
+              <input
+                className="game-mode-panel__code-input"
+                value={codeInput}
+                onChange={e => { setCodeInput(e.target.value.toUpperCase()); setCodeMsg(''); }}
+                onKeyDown={e => e.key === 'Enter' && handleRedeem()}
+                placeholder="Enter code"
+              />
+              <button type="button" className="game-mode-panel__code-submit" onClick={handleRedeem}>
+                Redeem
+              </button>
+            </div>
+          )}
+          {codeMsg && (
+            <p className={`game-mode-panel__code-msg game-mode-panel__code-msg--${codeMsg.startsWith('+') ? 'ok' : 'err'}`}>
+              {codeMsg}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default GameModePanel;

--- a/src/shared/overlays/SettingsMenu.jsx
+++ b/src/shared/overlays/SettingsMenu.jsx
@@ -4,6 +4,7 @@ import { useGame } from '../../context/GameContext.jsx';
 import { formatDailyDate } from '../../utils/seededRandom.js';
 import { STATUS } from '../../utils/gameConstants.js';
 import { A } from '../../utils/actionTypes.js';
+import { hasDailyBeenPlayed } from '../../utils/playLimits.js';
 import WordListModal from './WordListModal.jsx';
 import './SettingsMenu.css';
 
@@ -12,6 +13,7 @@ function SettingsMenu({ onClose, isMuted, onToggleMute, onPlayReplay }) {
   const { themeId, setThemeId, themes } = useTheme();
   const { state, dispatch } = useGame();
   const isPlaying = state.status !== STATUS.IDLE;
+  const dailyPlayed = hasDailyBeenPlayed();
 
   const title =
     s.panel === 'stats'       ? 'Stats'
@@ -47,9 +49,14 @@ function SettingsMenu({ onClose, isMuted, onToggleMute, onPlayReplay }) {
               <span>📊 Stats</span>
               <span aria-hidden="true">›</span>
             </button>
-            <button className="settings-menu__btn" onClick={() => s.openLeaderboard()}>
-              <span>🏆 Leaderboard</span>
-              <span aria-hidden="true">›</span>
+            <button
+              className="settings-menu__btn"
+              onClick={() => dailyPlayed && s.openLeaderboard()}
+              disabled={!dailyPlayed}
+              title={dailyPlayed ? undefined : "Play today's Daily Puzzle to unlock"}
+            >
+              <span>🏆 Leaderboard{!dailyPlayed ? ' 🔒' : ''}</span>
+              {dailyPlayed && <span aria-hidden="true">›</span>}
             </button>
             <button className="settings-menu__btn" onClick={s.openMyBest}>
               <span>🥇 My Best</span>

--- a/src/themes/classic/ClassicRoot.jsx
+++ b/src/themes/classic/ClassicRoot.jsx
@@ -5,6 +5,7 @@ import GameOverOverlay from './components/Overlays/GameOverOverlay.jsx';
 import { useGame } from '../../context/GameContext.jsx';
 import { STATUS } from '../../utils/gameConstants.js';
 import { A } from '../../utils/actionTypes.js';
+import GameModePanel from '../../shared/components/GameModePanel.jsx';
 import './styles/base.css';
 import './styles/card.css';
 import './styles/grid.css';
@@ -13,10 +14,6 @@ import './styles/made-words.css';
 function ClassicRoot({ dictionary, onHowToPlay, onLogin, onSettings }) {
   const { state, dispatch, undo } = useGame();
   const gridWrapperRef = useRef(null);
-
-  const handleStart = () => {
-    dispatch({ type: A.START_GAME, payload: { mode: 'clear' } });
-  };
 
   const handleRestart = () => {
     dispatch({ type: A.RESET });
@@ -53,7 +50,7 @@ function ClassicRoot({ dictionary, onHowToPlay, onLogin, onSettings }) {
         onInfo={onHowToPlay}
         onColumnClick={handleColumnClick}
         onUndo={undo}
-        onStartGame={handleStart}
+        renderStartOverlay={() => <GameModePanel dispatch={dispatch} className="start-game-overlay--classic" />}
         showPreview={state.status === STATUS.PLAYING || state.status === STATUS.PROCESSING}
       />
       <GameOverOverlay

--- a/src/themes/classic/components/Layout/GameLayout.jsx
+++ b/src/themes/classic/components/Layout/GameLayout.jsx
@@ -9,8 +9,6 @@ import { HowToPlayIcon, LoginIcon, LoggedInIcon, SettingsIcon } from '../../../.
 import { useCurrentUser } from '../../../../shared/hooks/useCurrentUser.js';
 import { GRID_COLS, GRID_ROWS } from '../../../../utils/gameConstants.js';
 import { useAmbientDemo } from '../../../../hooks/useAmbientDemo.js';
-import { formatDailyDate } from '../../../../utils/seededRandom.js';
-import StartGameOverlay from '../../../../shared/components/StartGameOverlay.jsx';
 
 function GameLayout({
   gridWrapperRef = null,
@@ -28,7 +26,7 @@ function GameLayout({
   onInfo,
   onColumnClick,
   onUndo,
-  onStartGame,
+  renderStartOverlay,
   showPreview = false,
 }) {
   const currentUser = useCurrentUser();
@@ -217,9 +215,7 @@ function GameLayout({
           </div>
         </div>
         <Board grid={displayGrid} onColumnClick={isIdle ? null : handleColumnClick} gridRef={gridRef} visible={true} />
-        {gameStatus === 'IDLE' && (
-          <StartGameOverlay className="start-game-overlay--classic" date={formatDailyDate()} onClick={onStartGame} />
-        )}
+        {gameStatus === 'IDLE' && renderStartOverlay?.()}
       </div>
 
       {/* Made Words Section (Bottom) */}

--- a/src/themes/classic/styles/base.css
+++ b/src/themes/classic/styles/base.css
@@ -384,6 +384,16 @@ body {
     box-shadow: 0 4px 10px rgba(25, 118, 210, 0.3);
 }
 
+.start-game-overlay--classic .start-game-btn__date {
+    display: block;
+    font-size: 0.7em;
+    font-weight: 400;
+    text-transform: none;
+    letter-spacing: 0;
+    opacity: 0.85;
+    margin-top: 2px;
+}
+
 .game-grid-wrapper--idle .preview-row {
     opacity: 0.4;
 }

--- a/src/themes/redesign/screens/GameOver.jsx
+++ b/src/themes/redesign/screens/GameOver.jsx
@@ -36,9 +36,10 @@ function GameOver() {
   const newWordsSet = useMemo(() => new Set(state.wordStats?.newWords ?? []), [state.wordStats]);
 
   const isClearMode = state.gameMode === 'clear';
+  const isDailyGame = state.gameType === 'daily';
 
   useEffect(() => {
-    if (isClearMode && state.wordStats !== undefined) {
+    if (isClearMode && isDailyGame && state.wordStats !== undefined) {
       setLoadingLeaderboard(true);
       const username = localStorage.getItem('noodel_username') ?? '';
       const today = new Date().toISOString().split('T')[0];
@@ -48,7 +49,7 @@ function GameOver() {
         .catch(() => setLeaderboard([]))
         .finally(() => setLoadingLeaderboard(false));
     }
-  }, [isClearMode, state.wordStats]);
+  }, [isClearMode, isDailyGame, state.wordStats]);
   const lettersRemaining = state.lettersRemaining;
   const lettersUsed = TOTAL_LETTERS - lettersRemaining;
   const boardCleared = isClearMode && state.initialBlocks.length > 0
@@ -83,7 +84,7 @@ function GameOver() {
   ];
 
   const onHome = () => dispatch({ type: A.RESET });
-  const onRestart = () => dispatch({ type: A.START_GAME, payload: { mode: state.gameMode } });
+  const onRestart = () => dispatch({ type: A.START_GAME, payload: { mode: state.gameMode, gameType: 'unlimited' } });
 
   return (
     <div className="rd-screen rd-gameover">
@@ -107,7 +108,7 @@ function GameOver() {
           <WordStatsBullets wordStats={state.wordStats} intro={statsIntro} />
         )}
 
-        {isClearMode && (
+        {isClearMode && isDailyGame && (
           <div style={{ marginTop: 24, paddingTop: 16, borderTop: '1px solid #e0e0e0' }}>
             <h3 style={{ marginBottom: 12, fontSize: '0.95em', fontWeight: 500 }}>Today's Clear Leaderboard</h3>
             {loadingLeaderboard ? (
@@ -130,6 +131,14 @@ function GameOver() {
                 }).flat()}
               </div>
             )}
+          </div>
+        )}
+
+        {isClearMode && !isDailyGame && (
+          <div style={{ marginTop: 24, paddingTop: 16, borderTop: '1px solid #e0e0e0', textAlign: 'center' }}>
+            <p style={{ color: '#666', fontSize: '0.9em' }}>
+              Play today's <strong>Daily Puzzle</strong> to compete on the leaderboard.
+            </p>
           </div>
         )}
 

--- a/src/themes/redesign/screens/Landing.jsx
+++ b/src/themes/redesign/screens/Landing.jsx
@@ -1,11 +1,107 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { useGame } from '../../../context/GameContext.jsx';
 import { A } from '../../../utils/actionTypes.js';
 import { formatDailyDate } from '../../../utils/seededRandom.js';
+import { hasDailyBeenPlayed, getUnlimitedRemaining, redeemCode } from '../../../utils/playLimits.js';
 import ActionBar from '../components/ActionBar.jsx';
 import NextRow from '../components/NextRow.jsx';
 import { useAmbientDemo, AmbientBoard } from '../components/AmbientDemo.jsx';
-import StartGameOverlay from '../../../shared/components/StartGameOverlay.jsx';
+
+function GameModePanel({ dispatch }) {
+  const [dailyPlayed] = useState(hasDailyBeenPlayed);
+  const [unlimitedLeft, setUnlimitedLeft] = useState(getUnlimitedRemaining);
+  const [showCode, setShowCode] = useState(false);
+  const [codeInput, setCodeInput] = useState('');
+  const [codeMsg, setCodeMsg] = useState('');
+
+  const startDaily = () => {
+    dispatch({ type: A.START_GAME, payload: { mode: 'clear', gameType: 'daily' } });
+  };
+
+  const startUnlimited = () => {
+    if (unlimitedLeft <= 0) return;
+    dispatch({ type: A.START_GAME, payload: { mode: 'clear', gameType: 'unlimited' } });
+  };
+
+  const handleRedeem = () => {
+    const result = redeemCode(codeInput);
+    if (result === 'ok') {
+      setCodeMsg('+10 plays added!');
+      setUnlimitedLeft(getUnlimitedRemaining());
+      setCodeInput('');
+    } else if (result === 'already_used') {
+      setCodeMsg('Already used today.');
+    } else {
+      setCodeMsg('Invalid code.');
+    }
+  };
+
+  const playsLabel = unlimitedLeft === 1 ? '1 play left' : `${unlimitedLeft} plays left`;
+
+  return (
+    <div className="start-game-overlay start-game-overlay--redesign">
+      <div style={{ marginBottom: 12 }}>
+        <button
+          type="button"
+          className="start-game-btn"
+          onClick={startDaily}
+          disabled={dailyPlayed}
+        >
+          Daily Puzzle
+          {dailyPlayed
+            ? <span className="start-game-btn__date">Played today ✓</span>
+            : <span className="start-game-btn__date">{formatDailyDate()}</span>
+          }
+        </button>
+      </div>
+
+      <div>
+        <button
+          type="button"
+          className="start-game-btn"
+          onClick={startUnlimited}
+          disabled={unlimitedLeft === 0}
+        >
+          Unlimited Play
+          <span className="start-game-btn__date">{playsLabel}</span>
+        </button>
+
+        <div style={{ marginTop: 8, textAlign: 'center' }}>
+          <button
+            type="button"
+            onClick={() => { setShowCode(v => !v); setCodeMsg(''); }}
+            style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '0.75em', opacity: 0.6, padding: '2px 0' }}
+          >
+            Have a code? {showCode ? '▲' : '▼'}
+          </button>
+          {showCode && (
+            <div style={{ display: 'flex', gap: 6, marginTop: 6, justifyContent: 'center' }}>
+              <input
+                value={codeInput}
+                onChange={e => { setCodeInput(e.target.value.toUpperCase()); setCodeMsg(''); }}
+                onKeyDown={e => e.key === 'Enter' && handleRedeem()}
+                placeholder="Enter code"
+                style={{ padding: '4px 8px', fontSize: '0.85em', borderRadius: 4, border: '1px solid #ccc', width: 120, textTransform: 'uppercase' }}
+              />
+              <button
+                type="button"
+                onClick={handleRedeem}
+                style={{ padding: '4px 10px', fontSize: '0.85em', borderRadius: 4, background: '#2e7d32', color: 'white', border: 'none', cursor: 'pointer' }}
+              >
+                Redeem
+              </button>
+            </div>
+          )}
+          {codeMsg && (
+            <p style={{ fontSize: '0.75em', marginTop: 4, color: codeMsg.startsWith('+') ? '#2e7d32' : '#c62828', margin: '4px 0 0' }}>
+              {codeMsg}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
 
 function Landing({ onHowToPlay, onLogin, onSettings }) {
   const { dispatch } = useGame();
@@ -38,11 +134,7 @@ function Landing({ onHowToPlay, onLogin, onSettings }) {
         <NextRow letters={demo.queue} firstTileRef={firstTileRef} />
         <div className="rd-board-stage">
           <AmbientBoard {...demo} firstTileRef={firstTileRef} />
-          <StartGameOverlay
-            className="start-game-overlay--redesign"
-            date={formatDailyDate()}
-            onClick={() => dispatch({ type: A.START_GAME, payload: { mode: 'clear' } })}
-          />
+          <GameModePanel dispatch={dispatch} />
         </div>
       </section>
     </div>

--- a/src/themes/redesign/screens/Landing.jsx
+++ b/src/themes/redesign/screens/Landing.jsx
@@ -1,107 +1,9 @@
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 import { useGame } from '../../../context/GameContext.jsx';
-import { A } from '../../../utils/actionTypes.js';
-import { formatDailyDate } from '../../../utils/seededRandom.js';
-import { hasDailyBeenPlayed, getUnlimitedRemaining, redeemCode } from '../../../utils/playLimits.js';
 import ActionBar from '../components/ActionBar.jsx';
 import NextRow from '../components/NextRow.jsx';
 import { useAmbientDemo, AmbientBoard } from '../components/AmbientDemo.jsx';
-
-function GameModePanel({ dispatch }) {
-  const [dailyPlayed] = useState(hasDailyBeenPlayed);
-  const [unlimitedLeft, setUnlimitedLeft] = useState(getUnlimitedRemaining);
-  const [showCode, setShowCode] = useState(false);
-  const [codeInput, setCodeInput] = useState('');
-  const [codeMsg, setCodeMsg] = useState('');
-
-  const startDaily = () => {
-    dispatch({ type: A.START_GAME, payload: { mode: 'clear', gameType: 'daily' } });
-  };
-
-  const startUnlimited = () => {
-    if (unlimitedLeft <= 0) return;
-    dispatch({ type: A.START_GAME, payload: { mode: 'clear', gameType: 'unlimited' } });
-  };
-
-  const handleRedeem = () => {
-    const result = redeemCode(codeInput);
-    if (result === 'ok') {
-      setCodeMsg('+10 plays added!');
-      setUnlimitedLeft(getUnlimitedRemaining());
-      setCodeInput('');
-    } else if (result === 'already_used') {
-      setCodeMsg('Already used today.');
-    } else {
-      setCodeMsg('Invalid code.');
-    }
-  };
-
-  const playsLabel = unlimitedLeft === 1 ? '1 play left' : `${unlimitedLeft} plays left`;
-
-  return (
-    <div className="start-game-overlay start-game-overlay--redesign">
-      <div style={{ marginBottom: 12 }}>
-        <button
-          type="button"
-          className="start-game-btn"
-          onClick={startDaily}
-          disabled={dailyPlayed}
-        >
-          Daily Puzzle
-          {dailyPlayed
-            ? <span className="start-game-btn__date">Played today ✓</span>
-            : <span className="start-game-btn__date">{formatDailyDate()}</span>
-          }
-        </button>
-      </div>
-
-      <div>
-        <button
-          type="button"
-          className="start-game-btn"
-          onClick={startUnlimited}
-          disabled={unlimitedLeft === 0}
-        >
-          Unlimited Play
-          <span className="start-game-btn__date">{playsLabel}</span>
-        </button>
-
-        <div style={{ marginTop: 8, textAlign: 'center' }}>
-          <button
-            type="button"
-            onClick={() => { setShowCode(v => !v); setCodeMsg(''); }}
-            style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '0.75em', opacity: 0.6, padding: '2px 0' }}
-          >
-            Have a code? {showCode ? '▲' : '▼'}
-          </button>
-          {showCode && (
-            <div style={{ display: 'flex', gap: 6, marginTop: 6, justifyContent: 'center' }}>
-              <input
-                value={codeInput}
-                onChange={e => { setCodeInput(e.target.value.toUpperCase()); setCodeMsg(''); }}
-                onKeyDown={e => e.key === 'Enter' && handleRedeem()}
-                placeholder="Enter code"
-                style={{ padding: '4px 8px', fontSize: '0.85em', borderRadius: 4, border: '1px solid #ccc', width: 120, textTransform: 'uppercase' }}
-              />
-              <button
-                type="button"
-                onClick={handleRedeem}
-                style={{ padding: '4px 10px', fontSize: '0.85em', borderRadius: 4, background: '#2e7d32', color: 'white', border: 'none', cursor: 'pointer' }}
-              >
-                Redeem
-              </button>
-            </div>
-          )}
-          {codeMsg && (
-            <p style={{ fontSize: '0.75em', marginTop: 4, color: codeMsg.startsWith('+') ? '#2e7d32' : '#c62828', margin: '4px 0 0' }}>
-              {codeMsg}
-            </p>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-}
+import GameModePanel from '../../../shared/components/GameModePanel.jsx';
 
 function Landing({ onHowToPlay, onLogin, onSettings }) {
   const { dispatch } = useGame();
@@ -134,7 +36,7 @@ function Landing({ onHowToPlay, onLogin, onSettings }) {
         <NextRow letters={demo.queue} firstTileRef={firstTileRef} />
         <div className="rd-board-stage">
           <AmbientBoard {...demo} firstTileRef={firstTileRef} />
-          <GameModePanel dispatch={dispatch} />
+          <GameModePanel dispatch={dispatch} className="start-game-overlay--redesign" />
         </div>
       </section>
     </div>

--- a/src/utils/playLimits.js
+++ b/src/utils/playLimits.js
@@ -1,0 +1,62 @@
+const DAILY_PLAYS = 3;
+const BONUS_PLAYS = 10;
+const VALID_CODES = ['NOODEL10'];
+
+export function getToday() {
+  return new Date().toISOString().split('T')[0];
+}
+
+function key(name) {
+  return `noodel_${name}_${getToday()}`;
+}
+
+export function hasDailyBeenPlayed() {
+  try {
+    return localStorage.getItem(key('daily_played')) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function markDailyPlayed() {
+  try {
+    localStorage.setItem(key('daily_played'), 'true');
+  } catch {
+    // ignore
+  }
+}
+
+export function getUnlimitedRemaining() {
+  try {
+    const used = parseInt(localStorage.getItem(key('unlimited_used')) ?? '0', 10);
+    const bonus = parseInt(localStorage.getItem(key('unlock_bonus')) ?? '0', 10);
+    return Math.max(0, DAILY_PLAYS + bonus - used);
+  } catch {
+    return DAILY_PLAYS;
+  }
+}
+
+export function consumeUnlimitedPlay() {
+  try {
+    const used = parseInt(localStorage.getItem(key('unlimited_used')) ?? '0', 10);
+    localStorage.setItem(key('unlimited_used'), String(used + 1));
+  } catch {
+    // ignore
+  }
+}
+
+// Returns 'ok' | 'invalid' | 'already_used'
+export function redeemCode(code) {
+  const normalized = (code ?? '').trim().toUpperCase();
+  if (!VALID_CODES.includes(normalized)) return 'invalid';
+  try {
+    const usedKey = `noodel_code_used_${normalized}_${getToday()}`;
+    if (localStorage.getItem(usedKey) === '1') return 'already_used';
+    localStorage.setItem(usedKey, '1');
+    const bonus = parseInt(localStorage.getItem(key('unlock_bonus')) ?? '0', 10);
+    localStorage.setItem(key('unlock_bonus'), String(bonus + BONUS_PLAYS));
+  } catch {
+    // ignore
+  }
+  return 'ok';
+}


### PR DESCRIPTION
## Summary

- Replaces the single "Start Game" button with two CTAs: **Daily Puzzle** (once/day, shared seed, scores to leaderboard) and **Unlimited Play** (3/day, random seed, practice-only)
- Unlock code `NOODEL10` grants +10 extra unlimited plays per day
- Leaderboard in Settings is locked (🔒) until the user has played today's Daily Puzzle
- "Play Again" on the game-over screen always starts an Unlimited game (daily is consumed)
- Shared `GameModePanel` component works across both the redesign and classic themes
- Buttons stack vertically with a clean layout; disabled state styled correctly

## Test plan

- [x] Landing (redesign) shows two buttons stacked vertically; Daily shows today's date, Unlimited shows remaining count
- [x] Landing (classic) shows the same two-button panel over the board
- [x] Clicking Daily starts a game; returning to landing shows "Played today ✓" (disabled)
- [x] Unlimited button decrements count on each play; disabled at 0
- [x] Entering `NOODEL10` adds +10; entering it again shows "Already used today"; garbage code shows "Invalid code"
- [x] Daily game-over shows leaderboard with score submitted; Unlimited game-over shows "Play today's Daily Puzzle" prompt
- [x] Settings → Leaderboard is 🔒 before daily is played; opens normally after
- [ ] Reload mid-daily game resumes correctly
- [x] `npm run build` passes ✅

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)