### PR TITLE
Add username-based login and account creation flow

### DIFF
--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -40,6 +40,17 @@ try {
     CREATE INDEX IF NOT EXISTS word_history_username_idx ON word_history (username);
   `);
   console.log('✅ word_history table ready');
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS users (
+      username   TEXT PRIMARY KEY,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+  `);
+  await pool.query(`
+    INSERT INTO users (username) VALUES ('yiding'), ('hannah')
+    ON CONFLICT DO NOTHING;
+  `);
+  console.log('✅ users table ready');
 } finally {
   await pool.end();
 }

--- a/server.js
+++ b/server.js
@@ -195,6 +195,36 @@ app.get('/api/user-stats', async (req, res) => {
   }
 });
 
+app.get('/api/users/check', async (req, res) => {
+  const { username } = req.query;
+  if (!username) return res.status(400).json({ error: 'username required' });
+  try {
+    const result = await pool.query('SELECT 1 FROM users WHERE username = $1', [username.trim().toLowerCase()]);
+    res.json({ available: result.rowCount === 0 });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+app.post('/api/users', async (req, res) => {
+  const raw = (req.body?.username ?? '').trim().toLowerCase();
+  if (!raw) return res.status(400).json({ error: 'username required' });
+  if (raw.length > 20) return res.status(400).json({ error: 'Username too long (max 20 characters)' });
+  if (!/^[a-zA-Z0-9_]+$/.test(raw)) return res.status(400).json({ error: 'Only letters, numbers, and underscores allowed' });
+  try {
+    const result = await pool.query(
+      'INSERT INTO users (username) VALUES ($1) ON CONFLICT DO NOTHING RETURNING username',
+      [raw]
+    );
+    if (result.rowCount === 0) return res.status(409).json({ error: 'Username already taken' });
+    res.status(201).json({ username: raw });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
 // Serve known HTML entry points directly; fall back to index.html for SPA routes
 const HTML_ENTRIES = ['index.html', 'poc.html'];
 app.get('*', (req, res) => {

--- a/src/shared/hooks/useSettingsState.js
+++ b/src/shared/hooks/useSettingsState.js
@@ -1,7 +1,5 @@
 import { useState } from 'react';
 
-export const USERS = ['yiding', 'hannah'];
-
 function getTodayDate() {
   const d = new Date();
   return d.toISOString().split('T')[0];

--- a/src/shared/overlays/LoginMenu.jsx
+++ b/src/shared/overlays/LoginMenu.jsx
@@ -1,15 +1,14 @@
-import { useSettingsState, USERS } from '../hooks/useSettingsState.js';
+import { useState, useEffect, useRef } from 'react';
+import { useSettingsState } from '../hooks/useSettingsState.js';
 import { NOODEL_LOGIN_EVENT } from '../hooks/useCurrentUser.js';
 import './SettingsMenu.css';
 
+const USERNAME_REGEX = /^[a-zA-Z0-9_]+$/;
+
 function LoginMenu({ onClose }) {
   const s = useSettingsState({ onClose });
-
-  const handleSelect = (name) => {
-    s.selectUser(name);
-    window.dispatchEvent(new CustomEvent(NOODEL_LOGIN_EVENT));
-    onClose?.();
-  };
+  // view: 'landing' | 'login' | 'create'
+  const [view, setView] = useState('landing');
 
   const handleLogout = () => {
     s.logout();
@@ -17,38 +16,210 @@ function LoginMenu({ onClose }) {
     onClose?.();
   };
 
+  const finish = (username) => {
+    s.selectUser(username);
+    window.dispatchEvent(new CustomEvent(NOODEL_LOGIN_EVENT));
+    onClose?.();
+  };
+
   return (
     <div className="settings-menu" onClick={onClose}>
       <div className="settings-menu__card" onClick={e => e.stopPropagation()}>
-        <button
-          type="button"
-          className="settings-menu__close"
-          onClick={onClose}
-          aria-label="Close login"
-        >✕</button>
-        <h2 className="settings-menu__title">Choose user</h2>
+        <button type="button" className="settings-menu__close" onClick={onClose} aria-label="Close">✕</button>
 
-        <div className="settings-menu__list">
-          {USERS.map(name => (
-            <button
-              key={name}
-              className={`settings-menu__btn${s.currentUser === name ? ' is-active' : ''}`}
-              onClick={() => handleSelect(name)}
-            >
-              <span>{s.currentUser === name ? '✓ ' : ''}{name.charAt(0).toUpperCase() + name.slice(1)}</span>
-            </button>
-          ))}
-          {s.currentUser && (
-            <button
-              className="settings-menu__btn settings-menu__btn--logout"
-              onClick={handleLogout}
-            >
-              Log out
-            </button>
-          )}
-        </div>
+        {s.currentUser ? (
+          <LoggedInView currentUser={s.currentUser} onLogout={handleLogout} />
+        ) : view === 'landing' ? (
+          <LandingView onLogin={() => setView('login')} onCreate={() => setView('create')} />
+        ) : view === 'login' ? (
+          <LoginView onBack={() => setView('landing')} onSuccess={finish} />
+        ) : (
+          <CreateView onBack={() => setView('landing')} onSuccess={finish} />
+        )}
       </div>
     </div>
+  );
+}
+
+function LoggedInView({ currentUser, onLogout }) {
+  return (
+    <>
+      <h2 className="settings-menu__title">Logged in</h2>
+      <div className="settings-menu__list">
+        <div className="settings-menu__btn is-active" style={{ cursor: 'default' }}>
+          <span>✓ {currentUser}</span>
+        </div>
+        <button className="settings-menu__btn settings-menu__btn--logout" onClick={onLogout}>
+          Log out
+        </button>
+      </div>
+    </>
+  );
+}
+
+function LandingView({ onLogin, onCreate }) {
+  return (
+    <>
+      <h2 className="settings-menu__title">Welcome</h2>
+      <div className="settings-menu__list">
+        <button className="settings-menu__btn login-form__submit login-form__submit--enabled" style={{ justifyContent: 'center' }} onClick={onLogin}>
+          Log in
+        </button>
+        <button className="settings-menu__btn" style={{ justifyContent: 'center' }} onClick={onCreate}>
+          Create username
+        </button>
+      </div>
+    </>
+  );
+}
+
+function LoginView({ onBack, onSuccess }) {
+  const [input, setInput] = useState('');
+  const [error, setError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const trimmed = input.trim().toLowerCase();
+    if (!trimmed) return;
+    setSubmitting(true);
+    setError('');
+    try {
+      const res = await fetch(`/api/users/check?username=${encodeURIComponent(trimmed)}`);
+      const data = await res.json();
+      if (!data.available) {
+        onSuccess(trimmed);
+      } else {
+        setError('No account with that username');
+      }
+    } catch {
+      setError('Could not reach server');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="login-header">
+        <button type="button" className="login-back" onClick={onBack} aria-label="Back">←</button>
+        <h2 className="settings-menu__title" style={{ margin: 0 }}>Log in</h2>
+      </div>
+      <form className="login-form" onSubmit={handleSubmit}>
+        <input
+          className="login-form__input"
+          type="text"
+          placeholder="Enter your username"
+          value={input}
+          onChange={e => { setInput(e.target.value); setError(''); }}
+          maxLength={21}
+          autoFocus
+          autoComplete="off"
+          autoCapitalize="none"
+          spellCheck={false}
+        />
+        {error && <span className="login-status login-status--err">✗ {error}</span>}
+        <button
+          className="settings-menu__btn login-form__submit login-form__submit--enabled"
+          type="submit"
+          disabled={!input.trim() || submitting}
+        >
+          {submitting ? 'Checking…' : 'Log in'}
+        </button>
+      </form>
+    </>
+  );
+}
+
+function CreateView({ onBack, onSuccess }) {
+  const [input, setInput] = useState('');
+  const [status, setStatus] = useState('idle'); // idle | checking | available | taken | invalid | error
+  const [statusMsg, setStatusMsg] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const debounceRef = useRef(null);
+
+  const check = (value) => {
+    clearTimeout(debounceRef.current);
+    const trimmed = value.trim().toLowerCase();
+    if (!trimmed) { setStatus('idle'); setStatusMsg(''); return; }
+    if (trimmed.length > 20) { setStatus('invalid'); setStatusMsg('Max 20 characters'); return; }
+    if (!USERNAME_REGEX.test(trimmed)) { setStatus('invalid'); setStatusMsg('Only letters, numbers, and underscores'); return; }
+    setStatus('checking');
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/users/check?username=${encodeURIComponent(trimmed)}`);
+        const data = await res.json();
+        if (data.available) { setStatus('available'); setStatusMsg('Available'); }
+        else { setStatus('taken'); setStatusMsg('Already taken'); }
+      } catch {
+        setStatus('error'); setStatusMsg('Could not reach server');
+      }
+    }, 400);
+  };
+
+  const handleChange = (e) => { setInput(e.target.value); check(e.target.value); };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (status !== 'available' || submitting) return;
+    const trimmed = input.trim().toLowerCase();
+    setSubmitting(true);
+    try {
+      const res = await fetch('/api/users', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username: trimmed }),
+      });
+      if (res.status === 409) { setStatus('taken'); setStatusMsg('Already taken'); return; }
+      if (!res.ok) { setStatus('error'); setStatusMsg('Something went wrong, try again'); return; }
+      const { username } = await res.json();
+      onSuccess(username);
+    } catch {
+      setStatus('error'); setStatusMsg('Something went wrong, try again');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  useEffect(() => () => clearTimeout(debounceRef.current), []);
+
+  const statusLabel = status === 'idle' ? '' :
+    status === 'checking' ? 'Checking…' :
+    status === 'available' ? `✓ ${statusMsg}` :
+    `✗ ${statusMsg}`;
+
+  const statusClass = { available: 'login-status--ok', checking: 'login-status--checking' }[status] ?? 'login-status--err';
+
+  return (
+    <>
+      <div className="login-header">
+        <button type="button" className="login-back" onClick={onBack} aria-label="Back">←</button>
+        <h2 className="settings-menu__title" style={{ margin: 0 }}>Create username</h2>
+      </div>
+      <p className="login-hint">Letters, numbers, and underscores only · Max 20 characters · Not case-sensitive</p>
+      <form className="login-form" onSubmit={handleSubmit}>
+        <input
+          className="login-form__input"
+          type="text"
+          placeholder="e.g. coolplayer42"
+          value={input}
+          onChange={handleChange}
+          maxLength={21}
+          autoFocus
+          autoComplete="off"
+          autoCapitalize="none"
+          spellCheck={false}
+        />
+        {statusLabel && <span className={`login-status ${statusClass}`}>{statusLabel}</span>}
+        <button
+          className={`settings-menu__btn login-form__submit${status === 'available' ? ' login-form__submit--enabled' : ''}`}
+          type="submit"
+          disabled={status !== 'available' || submitting}
+        >
+          {submitting ? 'Creating…' : 'Create & log in'}
+        </button>
+      </form>
+    </>
   );
 }
 

--- a/src/shared/overlays/SettingsMenu.css
+++ b/src/shared/overlays/SettingsMenu.css
@@ -228,3 +228,87 @@
 .settings-menu__row.is-user .settings-menu__rank {
   color: #16a34a;
 }
+
+/* Login / username creation form */
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.login-form__input {
+  width: 100%;
+  padding: 12px 14px;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  font-size: 15px;
+  font-family: inherit;
+  outline: none;
+  background: #f9fafb;
+  box-sizing: border-box;
+  transition: border-color 0.15s;
+}
+.login-form__input:focus {
+  border-color: #388E3C;
+  background: #fff;
+}
+.login-status {
+  font-size: 13px;
+  font-weight: 500;
+  padding: 2px 0;
+}
+.login-status--ok { color: #16a34a; }
+.login-status--err { color: #ef4444; }
+.login-status--checking { color: #9ca3af; }
+.login-form__submit {
+  justify-content: center;
+  transition: opacity 0.15s;
+}
+.login-form__submit:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.login-form__submit:not(:disabled) {
+  border-color: #388E3C;
+  background: #E8F5E9;
+  color: #2E7D32;
+}
+.login-form__submit:not(:disabled):hover {
+  background: #c8e6c9;
+}
+
+/* Login back button + header row */
+.login-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+.login-back {
+  background: none;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+  color: #6b7280;
+  padding: 0 4px;
+  line-height: 1;
+  font-family: inherit;
+}
+.login-back:hover { color: #111827; }
+
+/* Hint text in create view */
+.login-hint {
+  font-size: 12px;
+  color: #9ca3af;
+  margin: -8px 0 12px;
+  line-height: 1.5;
+}
+
+/* Enabled state for login/create submit buttons */
+.login-form__submit--enabled {
+  border-color: #388E3C;
+  background: #E8F5E9;
+  color: #2E7D32;
+}
+.login-form__submit--enabled:hover:not(:disabled) {
+  background: #c8e6c9;
+}


### PR DESCRIPTION
## Summary

- Replaces hardcoded "Yiding / Hannah" user selection with a proper username system backed by a `users` DB table
- Decouples login and create into two distinct flows: **Log in** (enter existing username) and **Create username** (register + real-time availability check)
- Usernames are case-insensitive, stored lowercase, alphanumeric + underscores, max 20 characters
- Existing users (yiding, hannah) seeded into the new table so scores/vocabulary stay linked
- Auto-login on same device via localStorage is unchanged

## Test plan

- [x] Run `npm run migrate` against local DB — `users` table created, yiding/hannah seeded
- [x] Log in flow: type "yiding" → logs in; type unknown name → shows "No account with that username"
- [x] Create flow: type taken name → ✗ Already taken (submit disabled); type new name → ✓ Available → creates and logs in
- [x] Log out → landing screen with both buttons visible
- [x] Refresh page → stays logged in (localStorage)
- [ ] **Production**: run `npm run migrate` against Railway DB after deploy

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)