### PR TITLE
Style vocabulary search CTA as interactive button

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,82 @@ The leaderboard shows a ▶ button next to each score. Clicking it fetches the s
 
 **Score deduplication** (`GameContext.jsx`): `scoreSubmittedRef` guards the `POST /api/scores` call so React Strict Mode's double-mount doesn't submit two entries. Reset to `false` on each `START_GAME`.
 
+## Testing
+
+### When to run Jest
+
+Use Jest for unit tests of game logic, utilities, and reducers:
+
+```bash
+npm test                                        # Run all tests
+npm test -- --testPathPattern=gameReducer       # Test a specific file
+npm run test:watch                              # Watch mode
+```
+
+**Test when you change:**
+- `src/context/GameReducer.js` — state transitions, action handling
+- `src/utils/wordUtils.js` — word-finding logic (horizontal/vertical detection)
+- `src/utils/gracePeriodUtils.js` — grace period word classification (skip/extend/add)
+- `src/utils/scoringUtils.js` — score calculation
+- Any utility in `src/utils/` with unit test coverage
+
+### When to test the API
+
+Use the running Express server to verify endpoint behavior:
+
+```bash
+npm run build && npm start
+# Server at http://localhost:3000
+```
+
+**Test when you change:**
+- `server.js` — routes, request handling, database queries
+- Response format or status codes
+
+**Key endpoints to verify:**
+
+| Endpoint | How to test |
+|---|---|
+| `GET /api/scores?gameMode=clear&date=YYYY-MM-DD` | `curl 'http://localhost:3000/api/scores?gameMode=clear&date=2026-05-25'` |
+| `GET /api/scores/my-best?username=test` | `curl 'http://localhost:3000/api/scores/my-best?username=test'` |
+| `POST /api/scores` | Submit a game score via the UI or curl |
+| `GET /api/scores/:id/session` | Click ▶ on a leaderboard score to verify replay data loads |
+| `GET /api/user-stats?username=test` | Settings → Stats panel |
+| `GET /api/vocabulary?username=test` | Settings → Vocabulary |
+
+### When to test the UI
+
+Use the running app in a browser to verify component behavior and visual correctness:
+
+```bash
+npm run build && npm start
+# App at http://localhost:3000
+```
+
+**Test when you change:**
+- `src/shared/overlays/SettingsMenu.jsx` — settings panels, buttons, lists
+- `src/themes/classic/components/Overlays/GameOverOverlay.jsx` — game-over screen
+- Theme files or styles
+- Any hook or component that affects what users see
+
+**Test flow:**
+
+1. Open `http://localhost:3000` in a browser
+2. Optionally set a username in DevTools → Application → LocalStorage (`noodel_username` = your test name)
+3. Interact with the changed UI (open Settings, complete a game, switch themes, etc.)
+4. Verify the expected behavior and visual result
+5. Check adjacent UI for regressions (e.g., alignment, colors, responsive layout)
+
+**Useful debug flags** (append to URL):
+
+```
+?skipAnimations=true     # Remove Framer Motion delays for faster testing
+?debug=true              # Show debug overlay with game state
+?debugGrid=true          # Show grid pattern on board
+```
+
+Example: `http://localhost:3000?skipAnimations=true&debug=true`
+
 ## Database
 
 The app requires `DATABASE_URL` in `.env`. The `.env` file has two URLs (`LOCAL_DATABASE_URL`, `RAILWAY_DATABASE_URL`) — toggle which one `DATABASE_URL` points to.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "concurrently": "^9.2.1",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "playwright": "^1.60.0",
         "puppeteer": "^25.0.4",
         "vite": "^5.0.8"
       },
@@ -5556,6 +5557,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "concurrently": "^9.2.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "playwright": "^1.60.0",
     "puppeteer": "^25.0.4",
     "vite": "^5.0.8"
   },

--- a/src/shared/overlays/SettingsMenu.css
+++ b/src/shared/overlays/SettingsMenu.css
@@ -203,6 +203,21 @@
   margin-top: 4px;
 }
 
+.settings-menu__btn--cta {
+  border-color: #388E3C;
+  background: #E8F5E9;
+  color: #2E7D32;
+  font-size: 12px;
+  padding: 6px 14px;
+  margin-top: 8px;
+  justify-content: center;
+  width: auto;
+}
+.settings-menu__btn--cta:hover {
+  background: #c8e6c9;
+  border-color: #2e7d32;
+}
+
 .settings-menu__leaderboard {
   display: flex;
   flex-direction: column;

--- a/src/shared/overlays/SettingsMenu.css
+++ b/src/shared/overlays/SettingsMenu.css
@@ -151,12 +151,20 @@
 .settings-menu__word-row {
   display: flex;
   justify-content: space-between;
+  align-items: center;
   padding: 8px 0;
   font-size: 14px;
   color: #4b5563;
   border-bottom: 1px solid #e5e7eb;
 }
 .settings-menu__word-row:last-child { border-bottom: none; }
+
+.settings-menu__word-tile {
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 10px 12px;
+}
 
 .settings-menu__leaderboard {
   display: flex;

--- a/src/shared/overlays/SettingsMenu.css
+++ b/src/shared/overlays/SettingsMenu.css
@@ -166,6 +166,43 @@
   padding: 10px 12px;
 }
 
+.settings-menu__stat-tile {
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 16px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+  font-family: inherit;
+  text-align: center;
+}
+.settings-menu__stat-tile:hover {
+  background: #ffffff;
+  border-color: #d1d5db;
+}
+.settings-menu__stat-tile__label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #9ca3af;
+}
+.settings-menu__stat-tile__number {
+  font-size: 28px;
+  font-weight: 700;
+  color: #111827;
+  line-height: 1.1;
+}
+.settings-menu__stat-tile__icon {
+  font-size: 20px;
+  margin-top: 4px;
+}
+
 .settings-menu__leaderboard {
   display: flex;
   flex-direction: column;

--- a/src/shared/overlays/SettingsMenu.jsx
+++ b/src/shared/overlays/SettingsMenu.jsx
@@ -102,42 +102,44 @@ function SettingsMenu({ onClose, isMuted, onToggleMute, onPlayReplay }) {
             ) : !s.stats || s.stats.vocabularySize === 0 ? (
               <p className="settings-menu__empty">No stats yet — play a game!</p>
             ) : (
-              <div className="settings-menu__stats">
-                <div className="settings-menu__stats-row">
-                  <span>Vocabulary size</span>
-                  <strong>{s.stats.vocabularySize}</strong>
+              <>
+                <div className="settings-menu__stats">
+                  <div className="settings-menu__stats-row">
+                    <span>Vocabulary size</span>
+                    <strong>{s.stats.vocabularySize}</strong>
+                  </div>
+                  {s.stats.topWords?.length > 0 && (
+                    <div className="settings-menu__words">
+                      <div className="settings-menu__subtitle">Top words</div>
+                      {s.stats.topWords.map(w => (
+                        <div key={w.word} className="settings-menu__word-row">
+                          <span>⭐ {w.word}</span>
+                          <span>×{w.count}</span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                  {s.stats.rareWords?.length > 0 && (
+                    <div className="settings-menu__words">
+                      <div className="settings-menu__subtitle">Rare finds</div>
+                      {s.stats.rareWords.map(w => (
+                        <div key={w.word} className="settings-menu__word-row">
+                          <span>💎 {w.word}</span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
                 </div>
-                {s.stats.topWords?.length > 0 && (
-                  <div className="settings-menu__words">
-                    <div className="settings-menu__subtitle">Top words</div>
-                    {s.stats.topWords.map(w => (
-                      <div key={w.word} className="settings-menu__word-row">
-                        <span>⭐ {w.word}</span>
-                        <span>×{w.count}</span>
-                      </div>
-                    ))}
-                  </div>
-                )}
-                {s.stats.rareWords?.length > 0 && (
-                  <div className="settings-menu__words">
-                    <div className="settings-menu__subtitle">Rare finds</div>
-                    {s.stats.rareWords.map(w => (
-                      <div key={w.word} className="settings-menu__word-row">
-                        <span>💎 {w.word}</span>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
+                <button
+                  className="settings-menu__btn"
+                  onClick={s.openVocabulary}
+                  style={{ marginTop: 8 }}
+                >
+                  <span>📖 Browse vocabulary ({s.stats.vocabularySize})</span>
+                  <span aria-hidden="true">›</span>
+                </button>
+              </>
             )}
-            <button
-              className="settings-menu__btn"
-              onClick={s.openVocabulary}
-              style={{ marginTop: 8 }}
-            >
-              <span>📖 Browse vocabulary ({s.stats.vocabularySize})</span>
-              <span aria-hidden="true">›</span>
-            </button>
             <button className="settings-menu__btn" onClick={() => s.setPanel(null)} style={{ marginTop: 12 }}>← Back</button>
           </div>
         )}

--- a/src/shared/overlays/SettingsMenu.jsx
+++ b/src/shared/overlays/SettingsMenu.jsx
@@ -114,29 +114,33 @@ function SettingsMenu({ onClose, isMuted, onToggleMute, onPlayReplay }) {
                     <span aria-hidden="true">›</span>
                   </span>
                 </button>
-                <div className="settings-menu__stats">
-                  {s.stats.topWords?.length > 0 && (
-                    <div className="settings-menu__words">
-                      <div className="settings-menu__subtitle">Top words</div>
-                      {s.stats.topWords.map(w => (
-                        <div key={w.word} className="settings-menu__word-row">
-                          <span>⭐ {w.word}</span>
-                          <span>×{w.count}</span>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                  {s.stats.rareWords?.length > 0 && (
-                    <div className="settings-menu__words">
-                      <div className="settings-menu__subtitle">Rare finds</div>
-                      {s.stats.rareWords.map(w => (
-                        <div key={w.word} className="settings-menu__word-row">
-                          <span>💎 {w.word}</span>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
+
+                {(s.stats.topWords?.length > 0 || s.stats.rareWords?.length > 0) && (
+                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+                    {s.stats.topWords?.length > 0 && (
+                      <div className="settings-menu__word-tile">
+                        <div className="settings-menu__subtitle">Top Favs</div>
+                        {s.stats.topWords.map(w => (
+                          <div key={w.word} className="settings-menu__word-row">
+                            <span>⭐ {w.word}</span>
+                            <span>×{w.timesMade}</span>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                    {s.stats.rareWords?.length > 0 && (
+                      <div className="settings-menu__word-tile">
+                        <div className="settings-menu__subtitle">Rare Finds</div>
+                        {s.stats.rareWords.map(w => (
+                          <div key={w.word} className="settings-menu__word-row">
+                            <span>💎 {w.word}</span>
+                            {w.isNew && <span style={{ fontSize: 10, color: '#16a34a', fontWeight: 700, textTransform: 'uppercase' }}>new</span>}
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
               </>
             )}
             <button className="settings-menu__btn" onClick={() => s.setPanel(null)} style={{ marginTop: 12 }}>← Back</button>

--- a/src/shared/overlays/SettingsMenu.jsx
+++ b/src/shared/overlays/SettingsMenu.jsx
@@ -103,11 +103,18 @@ function SettingsMenu({ onClose, isMuted, onToggleMute, onPlayReplay }) {
               <p className="settings-menu__empty">No stats yet — play a game!</p>
             ) : (
               <>
+                <button
+                  className="settings-menu__btn"
+                  onClick={s.openVocabulary}
+                  style={{ marginBottom: 8 }}
+                >
+                  <span>📖 Vocabulary</span>
+                  <span style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
+                    <strong style={{ fontSize: 18 }}>{s.stats.vocabularySize}</strong>
+                    <span aria-hidden="true">›</span>
+                  </span>
+                </button>
                 <div className="settings-menu__stats">
-                  <div className="settings-menu__stats-row">
-                    <span>Vocabulary size</span>
-                    <strong>{s.stats.vocabularySize}</strong>
-                  </div>
                   {s.stats.topWords?.length > 0 && (
                     <div className="settings-menu__words">
                       <div className="settings-menu__subtitle">Top words</div>
@@ -130,14 +137,6 @@ function SettingsMenu({ onClose, isMuted, onToggleMute, onPlayReplay }) {
                     </div>
                   )}
                 </div>
-                <button
-                  className="settings-menu__btn"
-                  onClick={s.openVocabulary}
-                  style={{ marginTop: 8 }}
-                >
-                  <span>📖 Browse vocabulary ({s.stats.vocabularySize})</span>
-                  <span aria-hidden="true">›</span>
-                </button>
               </>
             )}
             <button className="settings-menu__btn" onClick={() => s.setPanel(null)} style={{ marginTop: 12 }}>← Back</button>

--- a/src/shared/overlays/SettingsMenu.jsx
+++ b/src/shared/overlays/SettingsMenu.jsx
@@ -62,10 +62,6 @@ function SettingsMenu({ onClose, isMuted, onToggleMute, onPlayReplay }) {
               <span>🥇 My Best</span>
               <span aria-hidden="true">›</span>
             </button>
-            <button className="settings-menu__btn" onClick={s.openVocabulary}>
-              <span>📖 Vocabulary</span>
-              <span aria-hidden="true">›</span>
-            </button>
             <button className="settings-menu__btn" onClick={onToggleMute}>
               <span>{isMuted ? '🔇 Unmute' : '🔊 Sound'}</span>
             </button>
@@ -134,6 +130,14 @@ function SettingsMenu({ onClose, isMuted, onToggleMute, onPlayReplay }) {
                 )}
               </div>
             )}
+            <button
+              className="settings-menu__btn"
+              onClick={s.openVocabulary}
+              style={{ marginTop: 8 }}
+            >
+              <span>📖 Browse vocabulary ({s.stats.vocabularySize})</span>
+              <span aria-hidden="true">›</span>
+            </button>
             <button className="settings-menu__btn" onClick={() => s.setPanel(null)} style={{ marginTop: 12 }}>← Back</button>
           </div>
         )}

--- a/src/shared/overlays/SettingsMenu.jsx
+++ b/src/shared/overlays/SettingsMenu.jsx
@@ -104,15 +104,13 @@ function SettingsMenu({ onClose, isMuted, onToggleMute, onPlayReplay }) {
             ) : (
               <>
                 <button
-                  className="settings-menu__btn"
+                  className="settings-menu__stat-tile"
                   onClick={s.openVocabulary}
                   style={{ marginBottom: 8 }}
                 >
-                  <span>📖 Vocabulary</span>
-                  <span style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
-                    <strong style={{ fontSize: 18 }}>{s.stats.vocabularySize}</strong>
-                    <span aria-hidden="true">›</span>
-                  </span>
+                  <span className="settings-menu__stat-tile__label">Total Words</span>
+                  <strong className="settings-menu__stat-tile__number">{s.stats.vocabularySize}</strong>
+                  <span className="settings-menu__stat-tile__icon">📖</span>
                 </button>
 
                 {(s.stats.topWords?.length > 0 || s.stats.rareWords?.length > 0) && (

--- a/src/shared/overlays/SettingsMenu.jsx
+++ b/src/shared/overlays/SettingsMenu.jsx
@@ -111,6 +111,7 @@ function SettingsMenu({ onClose, isMuted, onToggleMute, onPlayReplay }) {
                   <span className="settings-menu__stat-tile__label">Total Words</span>
                   <strong className="settings-menu__stat-tile__number">{s.stats.vocabularySize}</strong>
                   <span className="settings-menu__stat-tile__icon">📖</span>
+                  <span className="settings-menu__btn settings-menu__btn--cta">Search vocab →</span>
                 </button>
 
                 {(s.stats.topWords?.length > 0 || s.stats.rareWords?.length > 0) && (

--- a/src/shared/overlays/SettingsMenu.jsx
+++ b/src/shared/overlays/SettingsMenu.jsx
@@ -119,10 +119,10 @@ function SettingsMenu({ onClose, isMuted, onToggleMute, onPlayReplay }) {
                   <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
                     {s.stats.topWords?.length > 0 && (
                       <div className="settings-menu__word-tile">
-                        <div className="settings-menu__subtitle">Top Favs</div>
+                        <div className="settings-menu__subtitle">⭐ Top Favs</div>
                         {s.stats.topWords.map(w => (
                           <div key={w.word} className="settings-menu__word-row">
-                            <span>⭐ {w.word}</span>
+                            <span>{w.word}</span>
                             <span>×{w.timesMade}</span>
                           </div>
                         ))}
@@ -130,10 +130,10 @@ function SettingsMenu({ onClose, isMuted, onToggleMute, onPlayReplay }) {
                     )}
                     {s.stats.rareWords?.length > 0 && (
                       <div className="settings-menu__word-tile">
-                        <div className="settings-menu__subtitle">Rare Finds</div>
+                        <div className="settings-menu__subtitle">💎 Rare Finds</div>
                         {s.stats.rareWords.map(w => (
                           <div key={w.word} className="settings-menu__word-row">
-                            <span>💎 {w.word}</span>
+                            <span>{w.word}</span>
                             {w.isNew && <span style={{ fontSize: 10, color: '#16a34a', fontWeight: 700, textTransform: 'uppercase' }}>new</span>}
                           </div>
                         ))}


### PR DESCRIPTION
## Summary

Make the "Search vocab →" call-to-action inside the vocabulary stat tile clearly interactive by styling it as a proper button using the green login button color scheme.

## Changes

- Apply `.settings-menu__btn` and `.settings-menu__btn--cta` classes to the CTA span
- Add CSS rule for `.settings-menu__btn--cta` with green button styling (#E8F5E9 bg, #2E7D32 text, #388E3C border)
- Add hover state with darker green background (#c8e6c9)

The vocabulary stat tile now displays as:
```
┌──────────────────────┐
│   TOTAL WORDS        │
│                      │
│      1,250           │
│                      │
│        📖            │
│                      │
│ [Search vocab →]     │  ← green interactive button
└──────────────────────┘
```

## Test plan

- [ ] Open `http://localhost:3000`
- [x] Play a game to populate stats
- [x] Open Settings → Stats
- [x] Verify "Search vocab →" appears as a green button
- [x] Hover the button and verify it darkens
- [x] Click the button and verify WordListModal opens with search