### PR TITLE
Fix daily puzzle home/resume flow and played-tracking timing

### DIFF
--- a/src/context/GameContext.jsx
+++ b/src/context/GameContext.jsx
@@ -73,7 +73,6 @@ export function GameProvider({ children }) {
       const rng = createSeededRng(seed);
       const initialQueue = buildInitialQueue(mode, rng);
       const { grid: initialGrid, initialBlocks } = buildInitialGrid(mode, rng);
-      if (gameType === 'daily') markDailyPlayed();
       if (gameType === 'unlimited') consumeUnlimitedPlay();
       const fullAction = { type: A.START_GAME, payload: { mode, gameType, initialQueue, initialGrid, initialBlocks } };
       recorderRef.current.record(fullAction);
@@ -86,8 +85,14 @@ export function GameProvider({ children }) {
     }
 
     if (action.type === A.RESET) {
-      recorderRef.current.reset();
-      sessionStorage.clear();
+      const isDailyInProgress =
+        stateRef.current.gameType === 'daily' &&
+        stateRef.current.status !== STATUS.GAME_OVER &&
+        stateRef.current.status !== STATUS.IDLE;
+      if (!isDailyInProgress) {
+        recorderRef.current.reset();
+        sessionStorage.clear();
+      }
       dispatch(action);
       return;
     }
@@ -103,10 +108,21 @@ export function GameProvider({ children }) {
     return true;
   }, [dispatch]);
 
+  const resumeSession = useCallback(() => {
+    const snap = sessionStorage.load();
+    if (!snap?.checkpoints?.length) return;
+    const hasGameOver = snap.events?.some(e => e.type === A.GAME_OVER);
+    if (hasGameOver) { sessionStorage.clear(); return; }
+    if (!recorderRef.current.loadSnapshot(snap)) { sessionStorage.clear(); return; }
+    const latest = snap.checkpoints[snap.checkpoints.length - 1];
+    dispatch({ type: A.LOAD_SAVED_GAME, payload: latest.state });
+  }, [dispatch]);
+
   // Submit score when game ends (daily only); always clear the session snapshot.
   useEffect(() => {
     if (state.status !== STATUS.GAME_OVER) return;
     sessionStorage.clear(); // game complete — nothing left to resume
+    if (state.gameType === 'daily') markDailyPlayed();
     if (!scoreSubmittedRef.current && state.gameType === 'daily') {
       scoreSubmittedRef.current = true;
       const username = localStorage.getItem('noodel_username') ?? 'anonymous';
@@ -129,7 +145,7 @@ export function GameProvider({ children }) {
   }, [state.status]);
 
   return (
-    <GameContext.Provider value={{ state, dispatch: wrappedDispatch, undo }}>
+    <GameContext.Provider value={{ state, dispatch: wrappedDispatch, undo, resumeSession }}>
       {children}
     </GameContext.Provider>
   );

--- a/src/context/GameReducer.js
+++ b/src/context/GameReducer.js
@@ -220,7 +220,7 @@ export function gameReducer(state, action) {
     }
 
     case A.LOAD_SAVED_GAME: {
-      const { grid, nextQueue, lettersRemaining, score, madeWords, gameMode, gameType, initialBlocks } = action.payload;
+      const { grid, nextQueue, lettersRemaining, score, madeWords, allWordsThisGame, gameMode, gameType, initialBlocks } = action.payload;
       return {
         ...initialState,
         grid,
@@ -228,6 +228,7 @@ export function gameReducer(state, action) {
         lettersRemaining,
         score,
         madeWords,
+        allWordsThisGame: allWordsThisGame || [],
         gameMode,
         gameType: gameType ?? null,
         initialBlocks: initialBlocks || [],

--- a/src/services/sessionRecorder.js
+++ b/src/services/sessionRecorder.js
@@ -20,7 +20,7 @@ const RECORDABLE = new Set([
 ]);
 
 // State fields needed to fully restore the reducer via LOAD_SAVED_GAME.
-const CHECKPOINT_FIELDS = ['grid', 'nextQueue', 'lettersRemaining', 'score', 'madeWords', 'gameMode', 'initialBlocks'];
+const CHECKPOINT_FIELDS = ['grid', 'nextQueue', 'lettersRemaining', 'score', 'madeWords', 'allWordsThisGame', 'gameMode', 'gameType', 'initialBlocks'];
 
 function pickCheckpointState(state) {
   const out = {};

--- a/src/services/sessionStorage.js
+++ b/src/services/sessionStorage.js
@@ -1,12 +1,13 @@
 // Tiny localStorage wrapper for the active game session.
-// Single key for now; per-user keying is a future swap.
 
-const STORAGE_KEY = 'noodel_session_v1';
+function storageKey() {
+  try { return `noodel_session_v1_${localStorage.getItem('noodel_username') ?? 'anonymous'}`; } catch { return 'noodel_session_v1_anonymous'; }
+}
 
 export function save(snapshot) {
   if (!snapshot) return;
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot));
+    localStorage.setItem(storageKey(), JSON.stringify(snapshot));
   } catch {
     // localStorage may be disabled (private mode), full, or otherwise unavailable.
     // Persistence is best-effort; the game must keep running.
@@ -15,7 +16,7 @@ export function save(snapshot) {
 
 export function load() {
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
+    const raw = localStorage.getItem(storageKey());
     if (!raw) return null;
     return JSON.parse(raw);
   } catch {
@@ -25,7 +26,7 @@ export function load() {
 
 export function clear() {
   try {
-    localStorage.removeItem(STORAGE_KEY);
+    localStorage.removeItem(storageKey());
   } catch {
     // ignore
   }

--- a/src/services/sessionStorage.js
+++ b/src/services/sessionStorage.js
@@ -30,3 +30,12 @@ export function clear() {
     // ignore
   }
 }
+
+export function peekDailyInProgress() {
+  const snap = load();
+  if (!snap?.checkpoints?.length) return false;
+  const hasGameOver = snap.events?.some(e => e.type === 'GAME_OVER');
+  if (hasGameOver) return false;
+  const start = snap.events?.find(e => e.type === 'START_GAME');
+  return start?.payload?.gameType === 'daily';
+}

--- a/src/shared/components/GameModePanel.css
+++ b/src/shared/components/GameModePanel.css
@@ -64,3 +64,11 @@
   transform: none !important;
   box-shadow: none !important;
 }
+
+.start-game-btn--resume {
+  background: #2e7d32;
+}
+
+.start-game-btn--resume:hover:not(:disabled) {
+  background: #1b5e20;
+}

--- a/src/shared/components/GameModePanel.jsx
+++ b/src/shared/components/GameModePanel.jsx
@@ -45,20 +45,20 @@ function GameModePanel({ dispatch, resumeSession, className = '' }) {
   return (
     <div className={`start-game-overlay${className ? ' ' + className : ''}`}>
       <div className="game-mode-panel__inner">
-        <button
-          type="button"
-          className="start-game-btn"
-          onClick={handleDailyClick}
-          disabled={dailyPlayed && !hasDailyResume}
-        >
-          Daily Puzzle
-          {dailyPlayed
-            ? <span className="start-game-btn__date">Played today ✓</span>
-            : hasDailyResume
-              ? <span className="start-game-btn__date">Resume →</span>
+        {hasDailyResume ? (
+          <button type="button" className="start-game-btn start-game-btn--resume" onClick={handleDailyClick}>
+            Resume
+            <span className="start-game-btn__date">Daily Puzzle in progress</span>
+          </button>
+        ) : (
+          <button type="button" className="start-game-btn" onClick={handleDailyClick} disabled={dailyPlayed}>
+            Daily Puzzle
+            {dailyPlayed
+              ? <span className="start-game-btn__date">Played today ✓</span>
               : <span className="start-game-btn__date">{formatDailyDate()}</span>
-          }
-        </button>
+            }
+          </button>
+        )}
 
         <button
           type="button"

--- a/src/shared/components/GameModePanel.jsx
+++ b/src/shared/components/GameModePanel.jsx
@@ -2,10 +2,12 @@ import { useState } from 'react';
 import { A } from '../../utils/actionTypes.js';
 import { formatDailyDate } from '../../utils/seededRandom.js';
 import { hasDailyBeenPlayed, getUnlimitedRemaining, redeemCode } from '../../utils/playLimits.js';
+import { peekDailyInProgress } from '../../services/sessionStorage.js';
 import './GameModePanel.css';
 
-function GameModePanel({ dispatch, className = '' }) {
+function GameModePanel({ dispatch, resumeSession, className = '' }) {
   const [dailyPlayed] = useState(hasDailyBeenPlayed);
+  const [hasDailyResume] = useState(() => !hasDailyBeenPlayed() && peekDailyInProgress());
   const [unlimitedLeft, setUnlimitedLeft] = useState(getUnlimitedRemaining);
   const [showCode, setShowCode] = useState(false);
   const [codeInput, setCodeInput] = useState('');
@@ -13,6 +15,11 @@ function GameModePanel({ dispatch, className = '' }) {
 
   const startDaily = () => {
     dispatch({ type: A.START_GAME, payload: { mode: 'clear', gameType: 'daily' } });
+  };
+
+  const handleDailyClick = () => {
+    if (hasDailyResume) resumeSession?.();
+    else startDaily();
   };
 
   const startUnlimited = () => {
@@ -41,13 +48,15 @@ function GameModePanel({ dispatch, className = '' }) {
         <button
           type="button"
           className="start-game-btn"
-          onClick={startDaily}
-          disabled={dailyPlayed}
+          onClick={handleDailyClick}
+          disabled={dailyPlayed && !hasDailyResume}
         >
           Daily Puzzle
           {dailyPlayed
             ? <span className="start-game-btn__date">Played today ✓</span>
-            : <span className="start-game-btn__date">{formatDailyDate()}</span>
+            : hasDailyResume
+              ? <span className="start-game-btn__date">Resume →</span>
+              : <span className="start-game-btn__date">{formatDailyDate()}</span>
           }
         </button>
 

--- a/src/shared/overlays/LoginMenu.jsx
+++ b/src/shared/overlays/LoginMenu.jsx
@@ -1,17 +1,21 @@
 import { useState, useEffect, useRef } from 'react';
 import { useSettingsState } from '../hooks/useSettingsState.js';
 import { NOODEL_LOGIN_EVENT } from '../hooks/useCurrentUser.js';
+import { useGame } from '../../context/GameContext.jsx';
+import { A } from '../../utils/actionTypes.js';
 import './SettingsMenu.css';
 
 const USERNAME_REGEX = /^[a-zA-Z0-9_]+$/;
 
 function LoginMenu({ onClose }) {
   const s = useSettingsState({ onClose });
+  const { dispatch } = useGame();
   // view: 'landing' | 'login' | 'create'
   const [view, setView] = useState('landing');
 
   const handleLogout = () => {
     s.logout();
+    dispatch({ type: A.RESET });
     window.dispatchEvent(new CustomEvent(NOODEL_LOGIN_EVENT));
     onClose?.();
   };

--- a/src/shared/overlays/LoginMenu.jsx
+++ b/src/shared/overlays/LoginMenu.jsx
@@ -3,13 +3,15 @@ import { useSettingsState } from '../hooks/useSettingsState.js';
 import { NOODEL_LOGIN_EVENT } from '../hooks/useCurrentUser.js';
 import { useGame } from '../../context/GameContext.jsx';
 import { A } from '../../utils/actionTypes.js';
+import { STATUS } from '../../utils/gameConstants.js';
 import './SettingsMenu.css';
 
 const USERNAME_REGEX = /^[a-zA-Z0-9_]+$/;
 
 function LoginMenu({ onClose }) {
   const s = useSettingsState({ onClose });
-  const { dispatch } = useGame();
+  const { dispatch, state } = useGame();
+  const isGameActive = state.status !== STATUS.IDLE;
   // view: 'landing' | 'login' | 'create'
   const [view, setView] = useState('landing');
 
@@ -22,6 +24,7 @@ function LoginMenu({ onClose }) {
 
   const finish = (username) => {
     s.selectUser(username);
+    if (isGameActive) dispatch({ type: A.RESET });
     window.dispatchEvent(new CustomEvent(NOODEL_LOGIN_EVENT));
     onClose?.();
   };
@@ -30,6 +33,12 @@ function LoginMenu({ onClose }) {
     <div className="settings-menu" onClick={onClose}>
       <div className="settings-menu__card" onClick={e => e.stopPropagation()}>
         <button type="button" className="settings-menu__close" onClick={onClose} aria-label="Close">✕</button>
+
+        {isGameActive && (
+          <p className="login-status login-status--warn">
+            ⚠ Logging in or out during a game returns you to the home screen
+          </p>
+        )}
 
         {s.currentUser ? (
           <LoggedInView currentUser={s.currentUser} onLogout={handleLogout} />

--- a/src/shared/overlays/SettingsMenu.css
+++ b/src/shared/overlays/SettingsMenu.css
@@ -319,6 +319,7 @@
 .login-status--ok { color: #16a34a; }
 .login-status--err { color: #ef4444; }
 .login-status--checking { color: #9ca3af; }
+.login-status--warn { color: #b45309; }
 .login-form__submit {
   justify-content: center;
   transition: opacity 0.15s;

--- a/src/themes/redesign/screens/Landing.jsx
+++ b/src/themes/redesign/screens/Landing.jsx
@@ -6,7 +6,7 @@ import { useAmbientDemo, AmbientBoard } from '../components/AmbientDemo.jsx';
 import GameModePanel from '../../../shared/components/GameModePanel.jsx';
 
 function Landing({ onHowToPlay, onLogin, onSettings }) {
-  const { dispatch } = useGame();
+  const { dispatch, resumeSession } = useGame();
   const demo = useAmbientDemo();
   const firstTileRef = useRef(null);
 
@@ -36,7 +36,7 @@ function Landing({ onHowToPlay, onLogin, onSettings }) {
         <NextRow letters={demo.queue} firstTileRef={firstTileRef} />
         <div className="rd-board-stage">
           <AmbientBoard {...demo} firstTileRef={firstTileRef} />
-          <GameModePanel dispatch={dispatch} className="start-game-overlay--redesign" />
+          <GameModePanel dispatch={dispatch} resumeSession={resumeSession} className="start-game-overlay--redesign" />
         </div>
       </section>
     </div>

--- a/src/utils/playLimits.js
+++ b/src/utils/playLimits.js
@@ -6,8 +6,12 @@ export function getToday() {
   return new Date().toISOString().split('T')[0];
 }
 
+function getUsername() {
+  try { return localStorage.getItem('noodel_username') ?? 'anonymous'; } catch { return 'anonymous'; }
+}
+
 function key(name) {
-  return `noodel_${name}_${getToday()}`;
+  return `noodel_${name}_${getUsername()}_${getToday()}`;
 }
 
 export function hasDailyBeenPlayed() {
@@ -50,7 +54,7 @@ export function redeemCode(code) {
   const normalized = (code ?? '').trim().toUpperCase();
   if (!VALID_CODES.includes(normalized)) return 'invalid';
   try {
-    const usedKey = `noodel_code_used_${normalized}_${getToday()}`;
+    const usedKey = `noodel_code_used_${normalized}_${getUsername()}_${getToday()}`;
     if (localStorage.getItem(usedKey) === '1') return 'already_used';
     localStorage.setItem(usedKey, '1');
     const bonus = parseInt(localStorage.getItem(key('unlock_bonus')) ?? '0', 10);


### PR DESCRIPTION
## Summary

- `markDailyPlayed()` now fires at `GAME_OVER`, not at `START_GAME` — quitting early no longer burns the daily slot
- Clicking Home mid-daily preserves the session; landing screen shows a large green **Resume** button
- Resume correctly restores `gameType` and `allWordsThisGame` (both were missing from `CHECKPOINT_FIELDS`)
- All localStorage keys (play limits + session) are now scoped per-username so multiple users on the same device don't interfere
- Logging out **or** logging in while a game is active resets to the landing screen; an amber warning in the login modal explains this

## Commits

| Commit | Change |
|---|---|
| `feat: add peekDailyInProgress helper` | sessionStorage peek for resume detection |
| `fix: move markDailyPlayed to GAME_OVER and preserve daily session on Home` | core daily flow fix |
| `feat: show Resume button on GameModePanel` | Resume wired to landing screen |
| `feat: key play limits by username` | per-user daily/unlimited counters |
| `feat: key game session by username` | per-user session storage |
| `fix: restore gameType and allWordsThisGame on resume` | checkpoint field bug |
| `feat: make Resume the dominant button` | green Resume replaces Daily Puzzle button |
| `fix: reset game to landing on logout` | logout → landing |
| `fix: reset game on login + warn user mid-game` | login → landing + amber warning |

## Test plan

- [x] Start daily → go Home → landing shows large green Resume button
- [x] Click Resume → grid/score/words restored exactly
- [x] Play to game over → score submits, "Played today ✓" appears
- [x] Quit daily early → daily slot NOT marked as played
- [x] Log in as "alice", play daily, log out → landing screen, session preserved under alice's key
- [ ] Log in as "bob" → no Resume prompt (different user key)
- [x] Open login modal mid-game → amber warning visible
- [x] Log in / create username mid-game → landing screen

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)