### PR TITLE
fix: session resume for daily and unlimited games

### DIFF
--- a/src/context/GameContext.jsx
+++ b/src/context/GameContext.jsx
@@ -85,11 +85,17 @@ export function GameProvider({ children }) {
     }
 
     if (action.type === A.RESET) {
-      const isDailyInProgress =
-        stateRef.current.gameType === 'daily' &&
+      const isGameInProgress =
         stateRef.current.status !== STATUS.GAME_OVER &&
         stateRef.current.status !== STATUS.IDLE;
-      if (!isDailyInProgress) {
+      if (isGameInProgress) {
+        // Capture current visible state so resume restores here, not pre-last-drop.
+        // Skip if PROCESSING (mid-animation) to avoid persisting a partially-animated grid.
+        if (stateRef.current.status === STATUS.PLAYING) {
+          recorderRef.current.recordCheckpoint(stateRef.current);
+        }
+        // onChange fires → sessionStorage.save automatically
+      } else {
         recorderRef.current.reset();
         sessionStorage.clear();
       }

--- a/src/services/sessionStorage.js
+++ b/src/services/sessionStorage.js
@@ -40,3 +40,12 @@ export function peekDailyInProgress() {
   const start = snap.events?.find(e => e.type === 'START_GAME');
   return start?.payload?.gameType === 'daily';
 }
+
+export function peekUnlimitedInProgress() {
+  const snap = load();
+  if (!snap?.checkpoints?.length) return false;
+  const hasGameOver = snap.events?.some(e => e.type === 'GAME_OVER');
+  if (hasGameOver) return false;
+  const start = snap.events?.find(e => e.type === 'START_GAME');
+  return start?.payload?.gameType === 'unlimited';
+}

--- a/src/shared/components/GameModePanel.jsx
+++ b/src/shared/components/GameModePanel.jsx
@@ -1,17 +1,24 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { A } from '../../utils/actionTypes.js';
 import { formatDailyDate } from '../../utils/seededRandom.js';
 import { hasDailyBeenPlayed, getUnlimitedRemaining, redeemCode } from '../../utils/playLimits.js';
 import { peekDailyInProgress } from '../../services/sessionStorage.js';
+import { useCurrentUser } from '../hooks/useCurrentUser.js';
 import './GameModePanel.css';
 
 function GameModePanel({ dispatch, resumeSession, className = '' }) {
-  const [dailyPlayed] = useState(hasDailyBeenPlayed);
-  const [hasDailyResume] = useState(() => !hasDailyBeenPlayed() && peekDailyInProgress());
+  const currentUser = useCurrentUser();
   const [unlimitedLeft, setUnlimitedLeft] = useState(getUnlimitedRemaining);
   const [showCode, setShowCode] = useState(false);
   const [codeInput, setCodeInput] = useState('');
   const [codeMsg, setCodeMsg] = useState('');
+
+  useEffect(() => {
+    setUnlimitedLeft(getUnlimitedRemaining());
+  }, [currentUser]);
+
+  const dailyPlayed = hasDailyBeenPlayed();
+  const hasDailyResume = !dailyPlayed && peekDailyInProgress();
 
   const startDaily = () => {
     dispatch({ type: A.START_GAME, payload: { mode: 'clear', gameType: 'daily' } });

--- a/src/shared/components/GameModePanel.jsx
+++ b/src/shared/components/GameModePanel.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { A } from '../../utils/actionTypes.js';
 import { formatDailyDate } from '../../utils/seededRandom.js';
 import { hasDailyBeenPlayed, getUnlimitedRemaining, redeemCode } from '../../utils/playLimits.js';
-import { peekDailyInProgress } from '../../services/sessionStorage.js';
+import { peekDailyInProgress, peekUnlimitedInProgress } from '../../services/sessionStorage.js';
 import { useCurrentUser } from '../hooks/useCurrentUser.js';
 import './GameModePanel.css';
 
@@ -19,6 +19,7 @@ function GameModePanel({ dispatch, resumeSession, className = '' }) {
 
   const dailyPlayed = hasDailyBeenPlayed();
   const hasDailyResume = !dailyPlayed && peekDailyInProgress();
+  const hasUnlimitedResume = peekUnlimitedInProgress();
 
   const startDaily = () => {
     dispatch({ type: A.START_GAME, payload: { mode: 'clear', gameType: 'daily' } });
@@ -32,6 +33,11 @@ function GameModePanel({ dispatch, resumeSession, className = '' }) {
   const startUnlimited = () => {
     if (unlimitedLeft <= 0) return;
     dispatch({ type: A.START_GAME, payload: { mode: 'clear', gameType: 'unlimited' } });
+  };
+
+  const handleUnlimitedClick = () => {
+    if (hasUnlimitedResume) resumeSession?.();
+    else startUnlimited();
   };
 
   const handleRedeem = () => {
@@ -67,15 +73,17 @@ function GameModePanel({ dispatch, resumeSession, className = '' }) {
           </button>
         )}
 
-        <button
-          type="button"
-          className="start-game-btn"
-          onClick={startUnlimited}
-          disabled={unlimitedLeft === 0}
-        >
-          Unlimited Play
-          <span className="start-game-btn__date">{playsLabel}</span>
-        </button>
+        {hasUnlimitedResume ? (
+          <button type="button" className="start-game-btn start-game-btn--resume" onClick={handleUnlimitedClick}>
+            Resume
+            <span className="start-game-btn__date">Unlimited game in progress</span>
+          </button>
+        ) : (
+          <button type="button" className="start-game-btn" onClick={handleUnlimitedClick} disabled={unlimitedLeft === 0}>
+            Unlimited Play
+            <span className="start-game-btn__date">{playsLabel}</span>
+          </button>
+        )}
 
         <div className="game-mode-panel__code">
           <button

--- a/src/themes/classic/ClassicRoot.jsx
+++ b/src/themes/classic/ClassicRoot.jsx
@@ -12,7 +12,7 @@ import './styles/grid.css';
 import './styles/made-words.css';
 
 function ClassicRoot({ dictionary, onHowToPlay, onLogin, onSettings }) {
-  const { state, dispatch, undo } = useGame();
+  const { state, dispatch, undo, resumeSession } = useGame();
   const gridWrapperRef = useRef(null);
 
   const handleRestart = () => {
@@ -50,7 +50,7 @@ function ClassicRoot({ dictionary, onHowToPlay, onLogin, onSettings }) {
         onInfo={onHowToPlay}
         onColumnClick={handleColumnClick}
         onUndo={undo}
-        renderStartOverlay={() => <GameModePanel dispatch={dispatch} className="start-game-overlay--classic" />}
+        renderStartOverlay={() => <GameModePanel dispatch={dispatch} resumeSession={resumeSession} className="start-game-overlay--classic" />}
         showPreview={state.status === STATUS.PLAYING || state.status === STATUS.PROCESSING}
       />
       <GameOverOverlay


### PR DESCRIPTION
## Summary

Two atomic fixes for game session resumption:

1. **Refresh daily puzzle state when user logs in** — Fix daily puzzle state getting stale when multiple users play on the same device. Now derives state reactively on each render and syncs unlimited plays remaining when the user changes.

2. **Save game state on home click and enable resume for both daily and unlimited games** — Capture checkpoint when user clicks Home mid-game so resume restores to the exact visible state, and extend resume support to unlimited games (not just daily).

## Related issues

Closes #111

## Verification

- Resume button appears after starting a game and clicking Home
- Resume works for both daily and unlimited games
- Switching users refreshes the daily puzzle state correctly