### PR TITLE
fix: correct dropping animation coords on mobile after pinch-zoom

### DIFF
--- a/src/shared/overlays/ReplayOverlay.jsx
+++ b/src/shared/overlays/ReplayOverlay.jsx
@@ -10,6 +10,15 @@ import './ReplayOverlay.css';
 
 const SPEED_OPTIONS = [1, 2];
 
+// Convert layout-viewport coordinates from getBoundingClientRect() into visual-viewport
+// coordinates for position:fixed elements, accounting for mobile pinch-zoom offsets
+function getVVOffset() {
+  return {
+    x: window.visualViewport?.offsetLeft ?? 0,
+    y: window.visualViewport?.offsetTop ?? 0,
+  };
+}
+
 function ReplayOverlay({ session, meta, onClose }) {
   const [state, dispatch] = useReducer(gameReducer, initialState);
   const [progress, setProgress] = useState({ index: 0, total: 0, playing: false, speed: 1 });
@@ -65,15 +74,16 @@ function ReplayOverlay({ session, meta, onClose }) {
 
     const token = dropTokenRef.current;
     const id = `replay-drop-${token}-${Date.now()}`;
+    const vv = getVVOffset();
 
     return new Promise((resolve) => {
       setActiveDrop({
         id,
         column,
         letter: queue[0].char,
-        from: { x: fromRect.left, y: fromRect.top },
-        toTop: { x: colLeft, y: gridRect.top },
-        toFinal: { x: colLeft, y: gridRect.top + destRow * rowHeight },
+        from: { x: fromRect.left - vv.x, y: fromRect.top - vv.y },
+        toTop: { x: colLeft - vv.x, y: gridRect.top - vv.y },
+        toFinal: { x: colLeft - vv.x, y: gridRect.top + destRow * rowHeight - vv.y },
         cellSize,
         onComplete: () => {
           // If a restart happened mid-animation, drop this dispatch on the floor.

--- a/src/themes/classic/components/Layout/GameLayout.jsx
+++ b/src/themes/classic/components/Layout/GameLayout.jsx
@@ -10,6 +10,15 @@ import { useCurrentUser } from '../../../../shared/hooks/useCurrentUser.js';
 import { GRID_COLS, GRID_ROWS } from '../../../../utils/gameConstants.js';
 import { useAmbientDemo } from '../../../../hooks/useAmbientDemo.js';
 
+// Convert layout-viewport coordinates from getBoundingClientRect() into visual-viewport
+// coordinates for position:fixed elements, accounting for mobile pinch-zoom offsets
+function getVVOffset() {
+  return {
+    x: window.visualViewport?.offsetLeft ?? 0,
+    y: window.visualViewport?.offsetTop ?? 0,
+  };
+}
+
 function GameLayout({
   gridWrapperRef = null,
   score = 0,
@@ -55,12 +64,13 @@ function GameLayout({
       const col = ambientDrop.col;
       const dr = ambientDrop.destRow;
       const colLeft = gridRect.left + col * colW + (colW - cellSize) / 2;
+      const vv = getVVOffset();
       setAmbientDropState({
         id: `ambient-${col}-${dr}-${Date.now()}`,
         letter: ambientDrop.letter,
-        from: { x: fromRect.left, y: fromRect.top },
-        toTop: { x: colLeft, y: gridRect.top },
-        toFinal: { x: colLeft, y: gridRect.top + dr * rowH },
+        from: { x: fromRect.left - vv.x, y: fromRect.top - vv.y },
+        toTop: { x: colLeft - vv.x, y: gridRect.top - vv.y },
+        toFinal: { x: colLeft - vv.x, y: gridRect.top + dr * rowH - vv.y },
         cellSize,
       });
     } else if (!ambientDrop) {
@@ -136,6 +146,7 @@ function GameLayout({
 
     const id = `${Date.now()}-${Math.random()}`;
 
+    const vv = getVVOffset();
     inFlightColumnsRef.current.set(column, columnInFlight + 1);
     inFlightCountRef.current++;
     setShiftKey(k => k + 1);
@@ -144,9 +155,9 @@ function GameLayout({
       id,
       column,
       letter: nextLetters[letterIndex],
-      from: { x: fromRect.left, y: fromRect.top },
-      toTop: { x: colLeft, y: gridRect.top },
-      toFinal: { x: colLeft, y: gridRect.top + destRow * rowHeight },
+      from: { x: fromRect.left - vv.x, y: fromRect.top - vv.y },
+      toTop: { x: colLeft - vv.x, y: gridRect.top - vv.y },
+      toFinal: { x: colLeft - vv.x, y: gridRect.top + destRow * rowHeight - vv.y },
       cellSize,
     }]);
   }, [nextLetters, getDestRow, onColumnClick]);

--- a/src/themes/redesign/screens/InGame.jsx
+++ b/src/themes/redesign/screens/InGame.jsx
@@ -6,6 +6,15 @@ import Shell from '../components/Shell.jsx';
 import Board from '../components/Board.jsx';
 import DroppingOverlay from '../../../shared/overlays/DroppingOverlay.jsx';
 
+// Convert layout-viewport coordinates from getBoundingClientRect() into visual-viewport
+// coordinates for position:fixed elements, accounting for mobile pinch-zoom offsets
+function getVVOffset() {
+  return {
+    x: window.visualViewport?.offsetLeft ?? 0,
+    y: window.visualViewport?.offsetTop ?? 0,
+  };
+}
+
 function InGame({ onHowToPlay, onLogin, onSettings }) {
   const { state, dispatch } = useGame();
 
@@ -50,6 +59,7 @@ function InGame({ onHowToPlay, onLogin, onSettings }) {
     const colLeft = gridRect.left + column * colWidth + (colWidth - cellSize) / 2;
 
     const id = `${Date.now()}-${Math.random()}`;
+    const vv = getVVOffset();
     inFlightColumnsRef.current.set(column, cif + 1);
     inFlightCountRef.current++;
 
@@ -57,9 +67,9 @@ function InGame({ onHowToPlay, onLogin, onSettings }) {
       id,
       column,
       letter: letter.char,
-      from:    { x: fromRect.left, y: fromRect.top },
-      toTop:   { x: colLeft, y: gridRect.top },
-      toFinal: { x: colLeft, y: gridRect.top + destRow * rowHeight },
+      from:    { x: fromRect.left - vv.x, y: fromRect.top - vv.y },
+      toTop:   { x: colLeft - vv.x, y: gridRect.top - vv.y },
+      toFinal: { x: colLeft - vv.x, y: gridRect.top + destRow * rowHeight - vv.y },
       cellSize,
     }]);
   }, [state.nextQueue, getDestRow, dispatch]);


### PR DESCRIPTION
## Summary

- Adds `getVVOffset()` helper to read `window.visualViewport.offsetLeft/Top` (falls back to 0 on non-supporting browsers)
- Subtracts the visual-viewport offset from all `getBoundingClientRect()` coordinates fed into `position: fixed` drop overlays
- Applied to all four callsites: `GameLayout` main drop, `GameLayout` ambient drop, `ReplayOverlay`, and `InGame` (redesign theme)

## Why

`position: fixed` elements are anchored to the **visual viewport**. `getBoundingClientRect()` returns coordinates in the **layout viewport** space. On desktop these are the same, but after a mobile pinch-zoom the visual viewport is panned within the layout — the two spaces diverge by `visualViewport.offsetLeft/Top`. Without compensation the dropping tile animates to the wrong position on screen.

The existing `touchAction: none` scroll lock only prevents *new* scroll during an animation; it can't compensate for zoom that already happened before the tap.

## Test plan

- [ ] Open on a real iOS/Android device, pinch-zoom to ~150%, tap a column — tile should land on the correct cell
- [ ] Chrome DevTools → iPhone simulation → use the zoom slider in the device toolbar (not CSS zoom) → tap a column
- [ ] No regression: desktop drops and non-zoomed mobile drops still animate correctly

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)