### PR TITLE
fix: contain ambient drops below Classic UI overlays with z-index scale

### DIFF
--- a/src/shared/overlays/ReplayOverlay.css
+++ b/src/shared/overlays/ReplayOverlay.css
@@ -1,7 +1,7 @@
 .replay-overlay {
   position: fixed;
   inset: 0;
-  z-index: 1000;
+  z-index: var(--z-overlay, 1000);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/shared/overlays/SettingsMenu.css
+++ b/src/shared/overlays/SettingsMenu.css
@@ -10,7 +10,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1100;
+  z-index: var(--z-modal, 1100);
   padding: 16px;
   backdrop-filter: blur(2px);
 }

--- a/src/shared/overlays/WordListModal.css
+++ b/src/shared/overlays/WordListModal.css
@@ -5,7 +5,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1200;
+  z-index: var(--z-modal-top, 1200);
   padding: 16px;
   backdrop-filter: blur(2px);
 }

--- a/src/themes/classic/styles/base.css
+++ b/src/themes/classic/styles/base.css
@@ -109,6 +109,17 @@
     --animation-delay-start-letter-drop: 80ms;
     --animation-delay-start-word-pause: 300ms;
     --animation-delay-start-clear-pause: 150ms;
+
+    /* Z-Index Scale */
+    --z-ambient-drop: 5;
+    --z-game-drop: 10;
+    --z-game-ui: 10;
+    --z-game-ui-focus: 11;
+    --z-start-overlay: 20;
+    --z-header-ui: 100;
+    --z-overlay: 1000;
+    --z-modal: 1100;
+    --z-modal-top: 1200;
 }
 
 body {
@@ -251,7 +262,7 @@ body {
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 1000;
+    z-index: var(--z-overlay);
     opacity: 0;
     transition: opacity 0.3s ease;
     pointer-events: none;
@@ -303,7 +314,7 @@ body {
     cursor: pointer;
     box-shadow: var(--shadow-button);
     transition: transform var(--transition-fast), box-shadow var(--transition-fast), opacity var(--transition-fast);
-    z-index: 100;
+    z-index: var(--z-header-ui);
 }
 
 .skip-tutorial-btn:hover {
@@ -354,7 +365,7 @@ body {
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 10;
+    z-index: var(--z-start-overlay);
     pointer-events: none;
 }
 
@@ -403,6 +414,7 @@ body {
 
 .dropping-letter-overlay.classic-ambient-dropping {
     /* opacity controlled via prop on DroppingOverlay */
+    z-index: var(--z-ambient-drop);
 }
 
 .classic-ambient-drop {
@@ -418,7 +430,7 @@ body {
     border-radius: var(--size-border-radius-small);
     box-sizing: border-box;
     pointer-events: none;
-    z-index: 5;
+    z-index: var(--z-ambient-drop);
 }
 
 /* Game Over Overlay */
@@ -435,7 +447,7 @@ body {
     opacity: 0;
     visibility: hidden;
     transition: opacity var(--transition-quick), visibility var(--transition-quick);
-    z-index: 1001;
+    z-index: calc(var(--z-overlay) + 1);
     pointer-events: none;
 }
 

--- a/src/themes/classic/styles/grid.css
+++ b/src/themes/classic/styles/grid.css
@@ -18,6 +18,7 @@
     gap: 10px;
     position: relative;
     overflow: hidden;
+    isolation: isolate;
 }
 
 /* Preview Row (contains preview tiles and letters remaining) */
@@ -185,7 +186,7 @@
     border: 2px solid var(--color-border-primary);
     border-radius: var(--size-border-radius-small);
     pointer-events: none;
-    z-index: 10;
+    z-index: var(--z-game-drop);
     transition: all var(--transition-quick);
 }
 
@@ -334,7 +335,7 @@
     animation: startGuideGlow 1s ease-in-out infinite;
     border: 2px solid #FF9800;
     background: rgba(255, 152, 0, 0.15);
-    z-index: 10;
+    z-index: var(--z-game-ui);
 }
 
 /* Focused square within a highlighted column (stronger visual) */
@@ -344,7 +345,7 @@
     background: rgba(255, 152, 0, 0.28);
     box-shadow: 0 0 24px 12px rgba(255, 152, 0, 0.75);
     transform: scale(1.06);
-    z-index: 11;
+    z-index: var(--z-game-ui-focus);
 }
 
 /* Menu Button Styles - Greyish Monotone (No Gradients) */

--- a/src/themes/redesign/styles/redesign.css
+++ b/src/themes/redesign/styles/redesign.css
@@ -4,6 +4,16 @@
 :root {
   /* Board width = COLS*CELL + (COLS-1)*GAP + 2*board-padding (6px) */
   --rd-board-w: calc(7 * 48px + 6 * 4px + 12px);
+
+  /* Z-Index Scale */
+  --z-ambient-drop: 5;
+  --z-game-drop: 1000;
+  --z-game-ui: 5;
+  --z-game-ui-focus: 6;
+  --z-header-ui: 100;
+  --z-overlay: 1000;
+  --z-modal: 1100;
+  --z-modal-top: 1200;
 }
 
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -54,7 +64,7 @@ button {
   background: rgba(17, 24, 39, 0.85);
   border-radius: var(--rd-radius-pill);
   box-shadow: var(--rd-shadow-lg);
-  z-index: 100;
+  z-index: var(--z-header-ui);
   backdrop-filter: blur(8px);
 }
 .rd-screen-picker__btn {
@@ -346,7 +356,7 @@ button {
 /* Falling letter overlay (rendered above the redesign board) */
 .dropping-letter-overlay {
   position: absolute;
-  z-index: 1000;
+  z-index: var(--z-game-drop);
   border-radius: var(--rd-radius-sm);
   pointer-events: none;
   font-family: var(--rd-font);
@@ -361,7 +371,7 @@ button {
 }
 
 .dropping-letter-overlay.rd-dropping-ambient {
-  z-index: 5;
+  z-index: var(--z-ambient-drop);
 }
 
 .rd-board--interactive .rd-cell { cursor: pointer; }
@@ -531,7 +541,7 @@ button {
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 5;
+  z-index: var(--z-game-ui);
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary

- Ambient falling letters in Classic idle screen were painting over the Settings menu and the Daily Puzzle / Unlimited Play game mode panel
- Root cause: `.game-grid-wrapper` had no stacking context, and the start overlay shared `z-index: 10` with drops — ambient drops won the CSS tiebreaker due to later DOM order
- Fix: `isolation: isolate` on `.game-grid-wrapper` contains all drops inside that stacking context; dedicated `--z-start-overlay: 20` gives the game mode panel a clear advantage over all drop animations (5/10)
- Added a named `--z-*` CSS custom property scale to both themes and all shared overlays so the layer hierarchy is self-documenting and not order-dependent

## Commits

1. `chore: introduce --z-* CSS custom property z-index scale` — renames existing raw values to variables in redesign.css and shared overlay CSS; no behavior change
2. `fix: contain ambient drops below Classic UI game mode panel and settings` — adds `isolation: isolate` + `--z-start-overlay: 20` + `--z-ambient-drop: 5` to classic theme

## Test plan

- [x] Classic idle screen: ambient letters fall **behind** the Daily Puzzle / Unlimited Play buttons
- [x] Classic idle screen: open Settings → overlay covers falling letters
- [x] Classic: start a game → drop animation still works normally
- [x] Redesign theme: no visual regressions (ambient drops, settings, overlays)

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)