### PR TITLE
fix: daily puzzle cross-device double-play and stale resume

### DIFF
--- a/server.js
+++ b/server.js
@@ -49,6 +49,13 @@ app.post('/api/scores', async (req, res) => {
     if (typeof score !== 'number') return res.status(400).json({ error: 'score required' });
     const user = username || 'anonymous';
     const datePart = (gameDate && /^\d{4}-\d{2}-\d{2}$/.test(gameDate)) ? gameDate : null;
+    if ((gameMode || 'classic') === 'clear') {
+      const dup = await pool.query(
+        `SELECT 1 FROM leaderboard WHERE username = $1 AND game_mode = 'clear' AND game_date = COALESCE($2::date, CURRENT_DATE) LIMIT 1`,
+        [user, datePart]
+      );
+      if (dup.rowCount > 0) return res.status(409).json({ error: 'already submitted' });
+    }
     const result = await pool.query(
       'INSERT INTO leaderboard (score, game_mode, username, session_data, game_date) VALUES ($1, $2, $3, $4, COALESCE($5::date, CURRENT_DATE)) RETURNING id, username, score, game_mode, created_at',
       [score, gameMode || 'classic', user, sessionData ? JSON.stringify(sessionData) : null, datePart]
@@ -118,6 +125,20 @@ app.get('/api/scores', async (req, res) => {
     res.json(result.rows);
   } catch (err) {
     console.error('GET /api/scores error:', err);
+    res.status(500).json({ error: 'internal server error' });
+  }
+});
+
+app.get('/api/daily-status', async (req, res) => {
+  try {
+    const username = req.query.username || 'anonymous';
+    const result = await pool.query(
+      `SELECT 1 FROM leaderboard WHERE username = $1 AND game_mode = 'clear' AND game_date = CURRENT_DATE LIMIT 1`,
+      [username]
+    );
+    res.json({ played: result.rowCount > 0 });
+  } catch (err) {
+    console.error('GET /api/daily-status error:', err);
     res.status(500).json({ error: 'internal server error' });
   }
 });

--- a/src/context/GameContext.jsx
+++ b/src/context/GameContext.jsx
@@ -60,6 +60,14 @@ export function GameProvider({ children }) {
     if (!snap || !Array.isArray(snap.checkpoints) || snap.checkpoints.length === 0) return;
     const hasGameOver = Array.isArray(snap.events) && snap.events.some(e => e.type === A.GAME_OVER);
     if (hasGameOver) { sessionStorage.clear(); return; }
+    const startEvent = snap.events?.find(e => e.type === A.START_GAME);
+    if (startEvent?.payload?.gameType === 'daily') {
+      const today = getLocalDateString();
+      if (!startEvent.payload.gameDate || startEvent.payload.gameDate !== today) {
+        sessionStorage.clear();
+        return;
+      }
+    }
     if (!recorderRef.current.loadSnapshot(snap)) { sessionStorage.clear(); return; }
     const latest = snap.checkpoints[snap.checkpoints.length - 1];
     dispatch({ type: A.LOAD_SAVED_GAME, payload: latest.state });
@@ -74,7 +82,7 @@ export function GameProvider({ children }) {
       const initialQueue = buildInitialQueue(mode, rng);
       const { grid: initialGrid, initialBlocks } = buildInitialGrid(mode, rng);
       if (gameType === 'unlimited') consumeUnlimitedPlay();
-      const fullAction = { type: A.START_GAME, payload: { mode, gameType, initialQueue, initialGrid, initialBlocks } };
+      const fullAction = { type: A.START_GAME, payload: { mode, gameType, gameDate: getLocalDateString(), initialQueue, initialGrid, initialBlocks } };
       recorderRef.current.record(fullAction);
       dispatch(fullAction);
       return;

--- a/src/services/sessionStorage.js
+++ b/src/services/sessionStorage.js
@@ -38,7 +38,10 @@ export function peekDailyInProgress() {
   const hasGameOver = snap.events?.some(e => e.type === 'GAME_OVER');
   if (hasGameOver) return false;
   const start = snap.events?.find(e => e.type === 'START_GAME');
-  return start?.payload?.gameType === 'daily';
+  if (start?.payload?.gameType !== 'daily') return false;
+  const today = new Date().toISOString().split('T')[0];
+  if (!start.payload.gameDate || start.payload.gameDate !== today) return false;
+  return true;
 }
 
 export function peekUnlimitedInProgress() {

--- a/src/shared/components/GameModePanel.jsx
+++ b/src/shared/components/GameModePanel.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { A } from '../../utils/actionTypes.js';
 import { formatDailyDate } from '../../utils/seededRandom.js';
-import { hasDailyBeenPlayed, getUnlimitedRemaining, redeemCode } from '../../utils/playLimits.js';
+import { hasDailyBeenPlayed, markDailyPlayed, getUnlimitedRemaining, redeemCode } from '../../utils/playLimits.js';
 import { peekDailyInProgress, peekUnlimitedInProgress } from '../../services/sessionStorage.js';
 import { useCurrentUser } from '../hooks/useCurrentUser.js';
 import './GameModePanel.css';
@@ -9,6 +9,7 @@ import './GameModePanel.css';
 function GameModePanel({ dispatch, resumeSession, className = '' }) {
   const currentUser = useCurrentUser();
   const [unlimitedLeft, setUnlimitedLeft] = useState(getUnlimitedRemaining);
+  const [dailyPlayed, setDailyPlayed] = useState(hasDailyBeenPlayed);
   const [showCode, setShowCode] = useState(false);
   const [codeInput, setCodeInput] = useState('');
   const [codeMsg, setCodeMsg] = useState('');
@@ -17,7 +18,20 @@ function GameModePanel({ dispatch, resumeSession, className = '' }) {
     setUnlimitedLeft(getUnlimitedRemaining());
   }, [currentUser]);
 
-  const dailyPlayed = hasDailyBeenPlayed();
+  useEffect(() => {
+    setDailyPlayed(hasDailyBeenPlayed());
+    if (!currentUser) return;
+    fetch(`/api/daily-status?username=${encodeURIComponent(currentUser)}`)
+      .then(r => r.json())
+      .then(data => {
+        if (data.played) {
+          markDailyPlayed();
+          setDailyPlayed(true);
+        }
+      })
+      .catch(() => {});
+  }, [currentUser]);
+
   const hasDailyResume = !dailyPlayed && peekDailyInProgress();
   const hasUnlimitedResume = peekUnlimitedInProgress();
 


### PR DESCRIPTION
## Summary

- **Cross-device double-play**: Playing the daily puzzle on one device no longer allows replaying it on a fresh device/browser. `GET /api/daily-status` is fetched on mount and account switch — the button disables as soon as the server confirms the user has played. `POST /api/scores` also rejects duplicate clear-mode submissions for the same username + date with HTTP 409, so the DB can't accumulate extra scores even if the client check is bypassed.
- **Stale resume across days**: An incomplete daily puzzle from a previous day no longer shows a "Resume" button the next day. `START_GAME` now records `gameDate` in the session snapshot; `peekDailyInProgress()` and the auto-resume effect both reject sessions where that date doesn't match today.

## Edge cases

- **Two devices playing concurrently** (neither has submitted yet): both can play; whichever finishes first wins. The second submission hits the 409 — the game-over screen still renders locally, just no word stats update.
- **Account switching on the same device**: the server fetch re-runs on `currentUser` change, and `dailyPlayed` state resets immediately to the new account's localStorage value before the response arrives.

## Test plan

- [ ] Complete a daily puzzle → clear localStorage → reload in same browser: button shows "Played today ✓" (server confirms)
- [ ] `curl 'http://localhost:3000/api/daily-status?username=X'` returns `{ "played": true }` after a score is submitted
- [ ] Second `POST /api/scores` for same user/date/gameMode=clear → HTTP 409
- [ ] Leave a daily puzzle incomplete → next day (or patch `getLocalDateString` to yesterday) → reload: "Resume" button does NOT appear
- [ ] Leave a daily puzzle incomplete today → reload same day: "Resume" still offered correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)