### PR TITLE
feat: landing page UX improvements

### DIFF
--- a/src/context/GameContext.jsx
+++ b/src/context/GameContext.jsx
@@ -51,28 +51,6 @@ export function GameProvider({ children }) {
     });
   }
 
-  // Auto-resume on first mount if a mid-game snapshot exists.
-  const resumedRef = useRef(false);
-  useEffect(() => {
-    if (resumedRef.current) return;
-    resumedRef.current = true;
-    const snap = sessionStorage.load();
-    if (!snap || !Array.isArray(snap.checkpoints) || snap.checkpoints.length === 0) return;
-    const hasGameOver = Array.isArray(snap.events) && snap.events.some(e => e.type === A.GAME_OVER);
-    if (hasGameOver) { sessionStorage.clear(); return; }
-    const startEvent = snap.events?.find(e => e.type === A.START_GAME);
-    if (startEvent?.payload?.gameType === 'daily') {
-      const today = getLocalDateString();
-      if (!startEvent.payload.gameDate || startEvent.payload.gameDate !== today) {
-        sessionStorage.clear();
-        return;
-      }
-    }
-    if (!recorderRef.current.loadSnapshot(snap)) { sessionStorage.clear(); return; }
-    const latest = snap.checkpoints[snap.checkpoints.length - 1];
-    dispatch({ type: A.LOAD_SAVED_GAME, payload: latest.state });
-  }, []);
-
   const wrappedDispatch = useCallback((action) => {
     if (action.type === A.START_GAME) {
       scoreSubmittedRef.current = false;

--- a/src/shared/components/GameModePanel.css
+++ b/src/shared/components/GameModePanel.css
@@ -5,7 +5,7 @@
   align-items: stretch;
   pointer-events: auto;
   min-width: 200px;
-  max-width: 240px;
+  max-width: 260px;
 }
 
 .game-mode-panel__code {
@@ -66,9 +66,23 @@
 }
 
 .start-game-btn--resume {
-  background: #2e7d32;
+  background: #FF9800;
 }
 
 .start-game-btn--resume:hover:not(:disabled) {
-  background: #1b5e20;
+  background: #F57C00;
+}
+
+/* Daily resume: outlined green — light fill, green border + text */
+.start-game-btn--resume-daily {
+  background: #E8F5E9 !important;
+  color: #388E3C !important;
+  border: 2px solid #388E3C !important;
+  box-shadow: none !important;
+  outline: none !important;
+  white-space: nowrap;
+}
+
+.start-game-btn--resume-daily:hover:not(:disabled) {
+  background: #d4edda !important;
 }

--- a/src/shared/components/GameModePanel.jsx
+++ b/src/shared/components/GameModePanel.jsx
@@ -34,6 +34,7 @@ function GameModePanel({ dispatch, resumeSession, className = '' }) {
 
   const hasDailyResume = !dailyPlayed && peekDailyInProgress();
   const hasUnlimitedResume = peekUnlimitedInProgress();
+  const unlimitedBlocked = hasDailyResume;
 
   const startDaily = () => {
     dispatch({ type: A.START_GAME, payload: { mode: 'clear', gameType: 'daily' } });
@@ -73,9 +74,9 @@ function GameModePanel({ dispatch, resumeSession, className = '' }) {
     <div className={`start-game-overlay${className ? ' ' + className : ''}`}>
       <div className="game-mode-panel__inner">
         {hasDailyResume ? (
-          <button type="button" className="start-game-btn start-game-btn--resume" onClick={handleDailyClick}>
-            Resume
-            <span className="start-game-btn__date">Daily Puzzle in progress</span>
+          <button type="button" className="start-game-btn start-game-btn--resume start-game-btn--resume-daily" onClick={handleDailyClick}>
+            Continue Daily →
+            <span className="start-game-btn__date">{formatDailyDate()}</span>
           </button>
         ) : (
           <button type="button" className="start-game-btn" onClick={handleDailyClick} disabled={dailyPlayed}>
@@ -89,13 +90,15 @@ function GameModePanel({ dispatch, resumeSession, className = '' }) {
 
         {hasUnlimitedResume ? (
           <button type="button" className="start-game-btn start-game-btn--resume" onClick={handleUnlimitedClick}>
-            Resume
+            Continue Unlimited →
             <span className="start-game-btn__date">Unlimited game in progress</span>
           </button>
         ) : (
-          <button type="button" className="start-game-btn" onClick={handleUnlimitedClick} disabled={unlimitedLeft === 0}>
+          <button type="button" className="start-game-btn" onClick={handleUnlimitedClick} disabled={unlimitedLeft === 0 || unlimitedBlocked}>
             Unlimited Play
-            <span className="start-game-btn__date">{playsLabel}</span>
+            <span className="start-game-btn__date">
+              {unlimitedBlocked ? 'Finish your daily first' : playsLabel}
+            </span>
           </button>
         )}
 

--- a/src/shared/components/LandingBanner.css
+++ b/src/shared/components/LandingBanner.css
@@ -1,0 +1,45 @@
+.landing-banner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 9px 16px;
+  font-size: 13px;
+  border-bottom: 1px solid;
+  flex-wrap: wrap;
+  text-align: center;
+}
+
+.landing-banner--guest {
+  background: #f9f9f9;
+  border-color: #e5e7eb;
+  color: #6b7280;
+}
+
+.landing-banner--loggedin {
+  background: #E8F5E9;
+  border-color: #A5D6A7;
+  color: #2E7D32;
+}
+
+.landing-banner--resume {
+  background: #FFF3E0;
+  border-color: #FFCC80;
+  color: #7c3800;
+}
+
+.landing-banner__link {
+  font-size: 13px;
+  font-weight: 700;
+  color: #388E3C;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.landing-banner--resume .landing-banner__link {
+  color: #E65100;
+}

--- a/src/shared/components/LandingBanner.jsx
+++ b/src/shared/components/LandingBanner.jsx
@@ -1,0 +1,41 @@
+import { useCurrentUser } from '../hooks/useCurrentUser.js';
+import { peekDailyInProgress } from '../../services/sessionStorage.js';
+import './LandingBanner.css';
+
+function LandingBanner({ onLogin }) {
+  const currentUser = useCurrentUser();
+  const hasDailyResume = currentUser ? peekDailyInProgress() : false;
+
+  if (!currentUser) {
+    return (
+      <div className="landing-banner landing-banner--guest">
+        <svg width="14" height="14" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+          <path d="M10 10a4 4 0 100-8 4 4 0 000 8z"/>
+          <path d="M2 18a8 8 0 0116 0"/>
+        </svg>
+        Playing as guest — scores won't be saved.{' '}
+        <button type="button" className="landing-banner__link" onClick={onLogin}>Log in</button>
+        {' '}or{' '}
+        <button type="button" className="landing-banner__link" onClick={onLogin}>Create account</button>
+      </div>
+    );
+  }
+
+  if (hasDailyResume) {
+    return (
+      <div className="landing-banner landing-banner--resume">
+        <span aria-hidden="true">⏸</span>
+        <strong>{currentUser}</strong>, you have a daily puzzle in progress.
+      </div>
+    );
+  }
+
+  return (
+    <div className="landing-banner landing-banner--loggedin">
+      <span aria-hidden="true">👋</span>
+      Welcome back, <strong>{currentUser}</strong> — ready for today's puzzle?
+    </div>
+  );
+}
+
+export default LandingBanner;

--- a/src/themes/classic/components/Layout/GameLayout.jsx
+++ b/src/themes/classic/components/Layout/GameLayout.jsx
@@ -10,6 +10,7 @@ import { useCurrentUser } from '../../../../shared/hooks/useCurrentUser.js';
 import { GRID_COLS, GRID_ROWS } from '../../../../utils/gameConstants.js';
 import { computeDropCoords } from '../../../../utils/dropCoordUtils.js';
 import { useAmbientDemo } from '../../../../hooks/useAmbientDemo.js';
+import LandingBanner from '../../../../shared/components/LandingBanner.jsx';
 
 function GameLayout({
   gridWrapperRef = null,
@@ -180,6 +181,8 @@ function GameLayout({
           </button>
         </div>
       </header>
+
+      {isIdle && <LandingBanner onLogin={onLogin} />}
 
       {/* Hero (wordmark + compact score) */}
       <div className="hero">

--- a/src/themes/redesign/components/ActionBar.jsx
+++ b/src/themes/redesign/components/ActionBar.jsx
@@ -17,15 +17,31 @@ function ActionBar({ items, className = '' }) {
         if (!def) return null;
         const { defaultHandler } = def;
         const isLogin = id === 'login';
-        const Icon = isLogin && currentUser ? LoggedInIcon : def.Icon;
-        const label = isLogin && currentUser ? currentUser : def.label;
+        if (isLogin && currentUser) {
+          return (
+            <button
+              key={id}
+              type="button"
+              className="rd-avatar-pill"
+              onClick={onClick || defaultHandler}
+              aria-label={`Logged in as ${currentUser}`}
+            >
+              <div className="rd-avatar-circle" aria-hidden="true">
+                {currentUser[0].toUpperCase()}
+              </div>
+              <span className="rd-avatar-name">{currentUser}</span>
+            </button>
+          );
+        }
+        const Icon = def.Icon;
+        const label = def.label;
         return (
           <button
             key={id}
             type="button"
-            className={`rd-action-btn${isLogin ? ' rd-action-btn--login' : ''}${isLogin && currentUser ? ' rd-action-btn--loggedin' : ''}`}
+            className={`rd-action-btn${isLogin ? ' rd-action-btn--login' : ''}`}
             onClick={onClick || defaultHandler}
-            aria-label={isLogin && currentUser ? `Logged in as ${currentUser}` : label}
+            aria-label={label}
           >
             <Icon />
             <span className="rd-action-btn__label">{label}</span>

--- a/src/themes/redesign/screens/Landing.jsx
+++ b/src/themes/redesign/screens/Landing.jsx
@@ -4,6 +4,7 @@ import ActionBar from '../components/ActionBar.jsx';
 import NextRow from '../components/NextRow.jsx';
 import { useAmbientDemo, AmbientBoard } from '../components/AmbientDemo.jsx';
 import GameModePanel from '../../../shared/components/GameModePanel.jsx';
+import LandingBanner from '../../../shared/components/LandingBanner.jsx';
 
 function Landing({ onHowToPlay, onLogin, onSettings }) {
   const { dispatch, resumeSession } = useGame();
@@ -23,6 +24,8 @@ function Landing({ onHowToPlay, onLogin, onSettings }) {
         <div aria-hidden="true" />
         <ActionBar items={rightActions} className="rd-action-bar--right" />
       </header>
+
+      <LandingBanner onLogin={onLogin} />
 
       <div className="rd-hero">
         <div className="rd-wordmark">

--- a/src/themes/redesign/styles/redesign.css
+++ b/src/themes/redesign/styles/redesign.css
@@ -106,6 +106,46 @@ button {
 .rd-action-bar--left  { justify-content: flex-start; gap: var(--rd-s-2); }
 .rd-action-bar--right { justify-content: flex-end;   gap: var(--rd-s-2); }
 
+/* ---------- Avatar pill (logged-in state in ActionBar) ---------- */
+
+.rd-avatar-pill {
+  display: flex;
+  align-items: center;
+  gap: var(--rd-s-2);
+  background: var(--rd-accent-soft);
+  border: 1.5px solid #A5D6A7;
+  border-radius: var(--rd-radius-pill);
+  padding: 4px 12px 4px 4px;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.15s;
+}
+.rd-avatar-pill:hover { background: #d4edda; }
+
+.rd-avatar-circle {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--rd-accent);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.rd-avatar-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--rd-accent-hover);
+  max-width: 100px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Compact app bar on small screens — stack label under icon */
 @media (max-width: 480px) {
   .rd-app-bar .rd-action-btn {


### PR DESCRIPTION
## Summary

- **fix: show landing page on refresh for in-progress game** — removes the auto-resume `useEffect` in `GameContext` that bypassed the landing page on mount; `GameModePanel`'s "Continue" button already calls `resumeSession()`
- **feat: add `LandingBanner` component** — contextual banner showing guest prompt (log in / create account), welcome-back message for logged-in users, or pause indicator when a daily is in progress
- **feat: integrate `LandingBanner` into landing screens** — mounted in both the redesign `Landing` screen and classic `GameLayout` (idle state only)
- **feat: update resume button labels and styling in `GameModePanel`** — "Resume" → "Continue Daily →" / "Continue Unlimited →"; daily-resume gets green outlined style; unlimited blocked while a daily is in progress
- **feat: avatar pill for logged-in users in redesign `ActionBar`** — replaces the plain login icon with a pill showing a coloured initial circle and truncated username

## Test plan

- [x] Refresh mid-game → landing page appears (not the in-progress board)
- [x] Landing page shows "Continue Daily →" button when a daily is in progress; clicking it resumes the game
- [x] Landing page shows "Continue Unlimited →" when an unlimited game is in progress
- [x] Unlimited button is disabled with "Finish your daily first" when a daily is in progress
- [x] `LandingBanner` shows guest message when not logged in, welcome-back when logged in, pause indicator when daily is in progress
- [x] Logged-in user sees avatar pill (initial + username) in top-right corner

🤖 Generated with [Claude Code](https://claude.com/claude-code)