### PR TITLE
feat: visual continuity between landing and in-game views

### DIFF
--- a/src/shared/components/LandingBanner.css
+++ b/src/shared/components/LandingBanner.css
@@ -5,9 +5,15 @@
   gap: 6px;
   padding: 9px 16px;
   font-size: 13px;
-  border-bottom: 1px solid;
+  border: 1px solid;
+  border-radius: var(--rd-radius-md, 10px);
   flex-wrap: wrap;
   text-align: center;
+  width: var(--rd-board-w, 100%);
+  max-width: 100%;
+  margin: 0 auto;
+  height: var(--banner-h, 9vh);
+  overflow: hidden;
 }
 
 .landing-banner--guest {
@@ -16,7 +22,8 @@
   color: #6b7280;
 }
 
-.landing-banner--loggedin {
+.landing-banner--loggedin,
+.landing-banner--new {
   background: #E8F5E9;
   border-color: #A5D6A7;
   color: #2E7D32;
@@ -42,4 +49,16 @@
 
 .landing-banner--resume .landing-banner__link {
   color: #E65100;
+}
+
+.landing-banner__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 99px;
+  font-size: 12px;
+  font-weight: 600;
+  background: rgba(0, 0, 0, 0.06);
+  color: inherit;
 }

--- a/src/shared/components/LandingBanner.jsx
+++ b/src/shared/components/LandingBanner.jsx
@@ -2,7 +2,7 @@ import { useCurrentUser } from '../hooks/useCurrentUser.js';
 import { peekDailyInProgress } from '../../services/sessionStorage.js';
 import './LandingBanner.css';
 
-function LandingBanner({ onLogin }) {
+function LandingBanner({ onLogin, clearStreak = 0, loginStreak = 0 }) {
   const currentUser = useCurrentUser();
   const hasDailyResume = currentUser ? peekDailyInProgress() : false;
 
@@ -26,6 +26,17 @@ function LandingBanner({ onLogin }) {
       <div className="landing-banner landing-banner--resume">
         <span aria-hidden="true">⏸</span>
         <strong>{currentUser}</strong>, you have a daily puzzle in progress.
+        {clearStreak > 0 && <span className="landing-banner__pill">🔥 {clearStreak}-day clear streak</span>}
+        {loginStreak > 0 && <span className="landing-banner__pill">📅 {loginStreak}-day login streak</span>}
+      </div>
+    );
+  }
+
+  if (clearStreak === 0 && loginStreak === 0) {
+    return (
+      <div className="landing-banner landing-banner--new">
+        <span aria-hidden="true">👋</span>
+        Welcome to Noodel, <strong>{currentUser}</strong>! Ready to drop some words?
       </div>
     );
   }
@@ -33,7 +44,9 @@ function LandingBanner({ onLogin }) {
   return (
     <div className="landing-banner landing-banner--loggedin">
       <span aria-hidden="true">👋</span>
-      Welcome back, <strong>{currentUser}</strong> — ready for today's puzzle?
+      Welcome back, <strong>{currentUser}</strong>!
+      {clearStreak > 0 && <span className="landing-banner__pill">🔥 {clearStreak}-day clear streak</span>}
+      {loginStreak > 0 && <span className="landing-banner__pill">📅 {loginStreak}-day login streak</span>}
     </div>
   );
 }

--- a/src/themes/redesign/components/AmbientDemo.jsx
+++ b/src/themes/redesign/components/AmbientDemo.jsx
@@ -6,14 +6,15 @@ import { computeDropCoords } from '../../../utils/dropCoordUtils.js';
 
 export { useAmbientDemo };
 
-export function AmbientBoard({ grid, dropping, highlight, firstTileRef }) {
+export function AmbientBoard({ grid, dropping, highlight }) {
   const gridRef = useRef(null);
   const containerRef = useRef(null);
+  const anchorRef = useRef(null);
   const [dropState, setDropState] = useState(null);
 
   useEffect(() => {
     if (dropping?.phase === 'falling') {
-      const tileEl = firstTileRef?.current;
+      const tileEl = anchorRef.current;
       const gridEl = gridRef.current;
       const containerEl = containerRef.current;
       if (!tileEl || !gridEl || !containerEl) return;
@@ -28,7 +29,7 @@ export function AmbientBoard({ grid, dropping, highlight, firstTileRef }) {
     } else if (!dropping) {
       setDropState(null);
     }
-  }, [dropping, firstTileRef]);
+  }, [dropping]);
 
   const cells = grid.map((letter) =>
     letter ? { ch: letter, state: 'filled' } : null
@@ -36,6 +37,20 @@ export function AmbientBoard({ grid, dropping, highlight, firstTileRef }) {
 
   return (
     <div ref={containerRef} style={{ position: 'relative' }}>
+      <div
+        ref={anchorRef}
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          top: -40,
+          left: '50%',
+          transform: 'translateX(-50%)',
+          width: 32,
+          height: 32,
+          opacity: 0,
+          pointerEvents: 'none',
+        }}
+      />
       <div className="rd-ambient-demo" aria-hidden="true">
         <Board cells={cells} highlightSet={highlight} boardRef={gridRef} />
       </div>

--- a/src/themes/redesign/components/Shell.jsx
+++ b/src/themes/redesign/components/Shell.jsx
@@ -62,6 +62,7 @@ function Shell({ score, lettersLeft, next, madeWords, dictionary, nextUpRef, onH
             </span>
           )}
         </div>
+        <p className="rd-tagline">A word-dropping puzzle</p>
       </div>
 
       <NextRow letters={next} lettersLeft={lettersLeft} firstTileRef={nextUpRef} />

--- a/src/themes/redesign/screens/Landing.jsx
+++ b/src/themes/redesign/screens/Landing.jsx
@@ -1,7 +1,5 @@
-import { useRef } from 'react';
 import { useGame } from '../../../context/GameContext.jsx';
 import ActionBar from '../components/ActionBar.jsx';
-import NextRow from '../components/NextRow.jsx';
 import { useAmbientDemo, AmbientBoard } from '../components/AmbientDemo.jsx';
 import GameModePanel from '../../../shared/components/GameModePanel.jsx';
 import LandingBanner from '../../../shared/components/LandingBanner.jsx';
@@ -12,7 +10,6 @@ const WORDMARK_LETTERS = ['N', 'O', 'O', 'D', 'E', 'L'];
 function Landing({ onHowToPlay, onLogin, onSettings }) {
   const { dispatch, resumeSession } = useGame();
   const demo = useAmbientDemo();
-  const firstTileRef = useRef(null);
   const username = localStorage.getItem('noodel_username') ?? null;
   const { loginStreak, clearStreak } = useStreaks(username);
 
@@ -33,8 +30,6 @@ function Landing({ onHowToPlay, onLogin, onSettings }) {
           <ActionBar items={rightActions} />
         </div>
       </header>
-
-      <LandingBanner onLogin={onLogin} />
 
       <div className="rd-hero">
         <div className="rd-wordmark">
@@ -57,10 +52,11 @@ function Landing({ onHowToPlay, onLogin, onSettings }) {
         <p className="rd-tagline">A word-dropping puzzle</p>
       </div>
 
+      <LandingBanner onLogin={onLogin} clearStreak={clearStreak} loginStreak={loginStreak} />
+
       <section className="rd-landing__stage">
-        <NextRow letters={demo.queue} firstTileRef={firstTileRef} />
         <div className="rd-board-stage">
-          <AmbientBoard {...demo} firstTileRef={firstTileRef} />
+          <AmbientBoard {...demo} />
           <GameModePanel dispatch={dispatch} resumeSession={resumeSession} className="start-game-overlay--redesign" />
         </div>
       </section>

--- a/src/themes/redesign/styles/redesign.css
+++ b/src/themes/redesign/styles/redesign.css
@@ -283,13 +283,17 @@ button {
 
 .rd-next-row {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: var(--rd-s-3);
   width: var(--rd-board-w);
   max-width: 100%;
   margin: 0 auto;
-  padding: 0 0 var(--rd-s-3);
+  padding: 0 var(--rd-s-4);
+  height: var(--banner-h);
+  border: 1px solid var(--rd-border);
+  border-radius: var(--rd-radius-md);
+  background: var(--rd-surface);
 }
 .rd-next-row__left {
   display: flex;
@@ -507,6 +511,7 @@ button {
 /* InGame board wrapper centers the fixed-size Board within available width */
 .rd-board-wrapper {
   padding: 0 var(--rd-s-4);
+  margin-top: var(--rd-s-3);
 }
 .rd-board-center {
   display: flex;
@@ -518,7 +523,7 @@ button {
 .rd-ambient-demo {
   pointer-events: none;
   opacity: 0.4;
-  width: min(90vw, 388px);
+  width: min(90vw, calc(var(--size-grid-max-height) * 7 / 6));
 }
 
 .rd-demo-drop {
@@ -670,13 +675,11 @@ button {
   flex-direction: column;
   gap: var(--rd-s-3);
   padding: 0 var(--rd-s-4);
+  margin-top: var(--rd-s-3);
   padding-bottom: max(var(--rd-s-4), env(safe-area-inset-bottom));
 }
 .rd-landing__stage .rd-board-stage {
   align-self: center;
-}
-.rd-landing__stage .rd-next-row {
-  opacity: 0.4;
 }
 
 .rd-board-stage {

--- a/src/themes/redesign/styles/tokens.css
+++ b/src/themes/redesign/styles/tokens.css
@@ -52,6 +52,9 @@
   --rd-fs-2xl:     32px;
   --rd-fs-display: clamp(40px, 10vw, 64px);
 
+  /* Shared banner / next-row height — keeps landing and in-game slot the same size */
+  --banner-h: 9vh;
+
   /* Shadows */
   --rd-shadow-sm:  0 1px 2px rgba(17, 24, 39, 0.06);
   --rd-shadow-md:  0 4px 12px rgba(17, 24, 39, 0.08);


### PR DESCRIPTION
## Summary

- Visual continuity improvements between the landing screen and in-game views (banner work).

## Test plan

- [ ] Open the app and verify the transition between landing and in-game looks correct
- [ ] Check for regressions on landing screen layout and in-game view

🤖 Generated with [Claude Code](https://claude.com/claude-code)