### PR TITLE
chore: update references for repo rename noodel_new -> noodel

### DIFF
--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -10,7 +10,7 @@ Take the request in $ARGUMENTS and do the following:
 
 2. **Create the issue** via `mcp__github__create_issue`:
     - owner: yidinghou
-    - repo: noodel_new
+    - repo: noodel
     - title: (refined title)
     - body: (refined body)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,7 +229,7 @@ Branch naming: `feat/`, `fix/`, `chore/` prefixes. PRs target `main`. After merg
 ### GitHub Issues
 
 When a task is associated with a GH issue:
-1. Read the issue before planning: `mcp__github__get_issue` (owner: yidinghou, repo: noodel_new, issue_number: N)
+1. Read the issue before planning: `mcp__github__get_issue` (owner: yidinghou, repo: noodel, issue_number: N)
 2. Follow the implementation plan in the issue comments
 3. Include `Closes #N` in the PR body so GitHub auto-closes the issue on merge
 
@@ -241,6 +241,6 @@ When a task is associated with a GH issue:
 ### Commit → PR → Merge flow
 1. Stage files by logical group and commit each atomically (`git add <specific files>`)
 2. `git push -u origin <branch>`
-3. Create PR via GitHub MCP: `mcp__github__create_pull_request` (owner: yidinghou, repo: noodel_new, base: main) — include `Closes #N` in the body when working from an issue
+3. Create PR via GitHub MCP: `mcp__github__create_pull_request` (owner: yidinghou, repo: noodel, base: main) — include `Closes #N` in the body when working from an issue
 4. Merge via GitHub MCP: `mcp__github__merge_pull_request` (merge_method: merge)
 5. `git checkout main && git pull && git branch -d <branch>`

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -89,7 +89,7 @@ Add URL parameters for debugging:
 The project is organized as a modern JavaScript application:
 
 ```
-noodel_new/
+noodel/
 ├── server.js           # Express server (for Railway)
 ├── package.json        # Dependencies & scripts  
 ├── railway.toml        # Railway configuration

--- a/REACT_MIGRATION_SUMMARY.md
+++ b/REACT_MIGRATION_SUMMARY.md
@@ -350,7 +350,7 @@ App (GameProvider)
 ## Final File Structure
 
 ```
-noodel_new/
+noodel/
 ├── public/
 │   └── words/              # Dictionary CSV files (5 files)
 ├── src/

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: process.env.RAILWAY_ENVIRONMENT ? '/noodel_new/' : '/',
+  base: '/',
   plugins: [
     react({
       jsxRuntime: 'automatic',


### PR DESCRIPTION
## Summary
- GitHub repo renamed `yidinghou/noodel_new` → `yidinghou/noodel` (old archived `Noodel` repo renamed to `noodel-old` to free up the name)
- Update in-repo references (`CLAUDE.md`, `.claude/commands/issue.md`, `DEPLOYMENT.md`, `REACT_MIGRATION_SUMMARY.md`) from `noodel_new` to `noodel`
- Simplify `vite.config.js`: remove the `RAILWAY_ENVIRONMENT` conditional that set base path to `/noodel_new/` — this didn't match how `server.js` serves `dist/` at root, so base is now always `'/'`

## Test plan
- [x] `npm run build` succeeds
- [x] `grep -rn "noodel_new\|noodel-new"` across `.md`/`.js`/`.jsx`/`.json` returns nothing
- [ ] After merge: verify Railway deployment still serves the app correctly at root
